### PR TITLE
fix(fsa filesystem): Don't throw when calling isFile with non existent parent dir

### DIFF
--- a/editor/src/util/fileSystems/FsaEditorFileSystem.js
+++ b/editor/src/util/fileSystems/FsaEditorFileSystem.js
@@ -202,7 +202,7 @@ export class FsaEditorFileSystem extends EditorFileSystem {
 		overrideError = true,
 	} = {}) {
 		const {dirPath, fileName} = this.splitDirFileName(path);
-		const dirHandle = await this.getDirHandle(dirPath, {create});
+		const dirHandle = await this.getDirHandle(dirPath, {create, overrideError});
 		await this.verifyHandlePermission(dirHandle, {writable: create});
 		let fileHandle = null;
 		try {

--- a/test/unit/editor/src/util/fileSystems/FsaEditorFileSystem/misc.test.js
+++ b/test/unit/editor/src/util/fileSystems/FsaEditorFileSystem/misc.test.js
@@ -71,6 +71,17 @@ Deno.test({
 });
 
 Deno.test({
+	name: "isFile non existent parent",
+	fn: async () => {
+		const {fs} = createBasicFs();
+
+		const isFile = await fs.isFile(["root", "nonExistent", "file"]);
+
+		assertEquals(isFile, false);
+	},
+});
+
+Deno.test({
 	name: "isDir true",
 	fn: async () => {
 		const {fs} = createBasicFs();
@@ -98,6 +109,17 @@ Deno.test({
 		const {fs} = createBasicFs();
 
 		const isDir = await fs.isDir(["root", "nonExistent"]);
+
+		assertEquals(isDir, false);
+	},
+});
+
+Deno.test({
+	name: "isDir non existent parent",
+	fn: async () => {
+		const {fs} = createBasicFs();
+
+		const isDir = await fs.isDir(["root", "nonExistent", "dir"]);
 
 		assertEquals(isDir, false);
 	},

--- a/test/unit/editor/src/util/fileSystems/IndexedDbEditorFileSystem/misc.test.js
+++ b/test/unit/editor/src/util/fileSystems/IndexedDbEditorFileSystem/misc.test.js
@@ -348,6 +348,17 @@ Deno.test({
 });
 
 Deno.test({
+	name: "isFile non existent parent",
+	fn: async () => {
+		const fs = await createBasicFs();
+
+		const isFile = await fs.isFile(["root", "nonExistent", "file"]);
+
+		assertEquals(isFile, false);
+	},
+});
+
+Deno.test({
 	name: "isDir true",
 	fn: async () => {
 		const fs = await createBasicFs();
@@ -375,6 +386,17 @@ Deno.test({
 		const fs = await createBasicFs();
 
 		const isDir = await fs.isDir(["root", "nonExistent"]);
+
+		assertEquals(isDir, false);
+	},
+});
+
+Deno.test({
+	name: "isDir non existent parent",
+	fn: async () => {
+		const fs = await createBasicFs();
+
+		const isDir = await fs.isDir(["root", "nonExistent", "dir"]);
 
 		assertEquals(isDir, false);
 	},

--- a/test/unit/editor/src/util/fileSystems/MemoryEditorFileSystem/isDir.test.js
+++ b/test/unit/editor/src/util/fileSystems/MemoryEditorFileSystem/isDir.test.js
@@ -33,3 +33,14 @@ Deno.test({
 		assertEquals(isDir, false);
 	},
 });
+
+Deno.test({
+	name: "isDir non existent parent",
+	fn: async () => {
+		const fs = await createBasicFs();
+
+		const isDir = await fs.isDir(["root", "nonExistent", "dir"]);
+
+		assertEquals(isDir, false);
+	},
+});

--- a/test/unit/editor/src/util/fileSystems/MemoryEditorFileSystem/isFile.test.js
+++ b/test/unit/editor/src/util/fileSystems/MemoryEditorFileSystem/isFile.test.js
@@ -33,3 +33,14 @@ Deno.test({
 		assertEquals(isFile, false);
 	},
 });
+
+Deno.test({
+	name: "isFile non existent parent",
+	fn: async () => {
+		const fs = await createBasicFs();
+
+		const isFile = await fs.isFile(["root", "nonExistent", "file"]);
+
+		assertEquals(isFile, false);
+	},
+});


### PR DESCRIPTION
Fixes #28