### PR TITLE
fix(droppablegui): Fix error when dropping on a gui which supports all asset types

### DIFF
--- a/editor/src/propertiesAssetContent/AssetBundlePropertiesAssetContent.js
+++ b/editor/src/propertiesAssetContent/AssetBundlePropertiesAssetContent.js
@@ -1,5 +1,4 @@
 import {PropertiesAssetContent} from "./PropertiesAssetContent.js";
-import {ProjectAsset} from "../assets/ProjectAsset.js";
 import {createTreeViewStructure} from "../ui/propertiesTreeView/createStructureHelpers.js";
 
 /**
@@ -39,9 +38,6 @@ export class AssetBundlePropertiesAssetContent extends PropertiesAssetContent {
 						structure: {
 							asset: {
 								type: "droppable",
-								guiOpts: {
-									supportedAssetTypes: [ProjectAsset],
-								},
 							},
 							includeChildren: {
 								type: "boolean",
@@ -57,18 +53,12 @@ export class AssetBundlePropertiesAssetContent extends PropertiesAssetContent {
 				type: "array",
 				guiOpts: {
 					arrayType: "droppable",
-					arrayGuiOpts: {
-						supportedAssetTypes: [ProjectAsset],
-					},
 				},
 			},
 			excludeAssetsRecursive: {
 				type: "array",
 				guiOpts: {
 					arrayType: "droppable",
-					arrayGuiOpts: {
-						supportedAssetTypes: [ProjectAsset],
-					},
 				},
 			},
 		});

--- a/editor/src/windowManagement/contentWindows/DefaultAssetLinksContentWindow.js
+++ b/editor/src/windowManagement/contentWindows/DefaultAssetLinksContentWindow.js
@@ -1,6 +1,5 @@
 import {ContentWindow} from "./ContentWindow.js";
 import {PropertiesTreeView} from "../../ui/propertiesTreeView/PropertiesTreeView.js";
-import {ProjectAsset} from "../../assets/ProjectAsset.js";
 import {createTreeViewEntryOptions, createTreeViewStructure} from "../../ui/propertiesTreeView/createStructureHelpers.js";
 
 export class DefaultAssetLinksContentWindow extends ContentWindow {
@@ -94,14 +93,10 @@ export class DefaultAssetLinksContentWindow extends ContentWindow {
 		const restStructure = createTreeViewStructure({
 			originalAsset: {
 				type: "droppable",
-				guiOpts: {
-					supportedAssetTypes: [ProjectAsset],
-				},
 			},
 			defaultAsset: {
 				type: "droppable",
 				guiOpts: {
-					supportedAssetTypes: [ProjectAsset],
 					disabled: true,
 				},
 			},

--- a/importmap.json
+++ b/importmap.json
@@ -3,7 +3,7 @@
 		"std/": "https://deno.land/std@0.151.0/",
 		"chdir-anywhere": "https://deno.land/x/chdir_anywhere@v0.0.2/mod.js",
 		"fake-imports": "https://deno.land/x/fake_imports@v0.6.0/mod.js",
-		"fake-dom/": "https://raw.githubusercontent.com/jespertheend/fake-dom/main/src/",
+		"fake-dom/": "https://deno.land/x/fake_dom@v0.0.1/src/",
 		"puppeteer": "https://deno.land/x/puppeteer@14.1.1/mod.ts",
 		"rollup": "https://esm.sh/rollup@2.61.1?pin=v64",
 		"rollup-plugin-jscc": "https://esm.sh/rollup-plugin-jscc@2.0.0?pin=v64",

--- a/importmap.json
+++ b/importmap.json
@@ -3,7 +3,7 @@
 		"std/": "https://deno.land/std@0.151.0/",
 		"chdir-anywhere": "https://deno.land/x/chdir_anywhere@v0.0.2/mod.js",
 		"fake-imports": "https://deno.land/x/fake_imports@v0.6.0/mod.js",
-		"fake-dom/": "https://deno.land/x/fake_dom@v0.0.1/src/",
+		"fake-dom/": "https://deno.land/x/fake_dom@v0.0.2/src/",
 		"puppeteer": "https://deno.land/x/puppeteer@14.1.1/mod.ts",
 		"rollup": "https://esm.sh/rollup@2.61.1?pin=v64",
 		"rollup-plugin-jscc": "https://esm.sh/rollup-plugin-jscc@2.0.0?pin=v64",

--- a/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
+++ b/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
@@ -1,0 +1,144 @@
+import {assertEquals} from "std/testing/asserts.ts";
+import {stub} from "std/testing/mock.ts";
+import {FakeDragEvent} from "fake-dom/FakeDragEvent.js";
+import {createBasicGui} from "./shared.js";
+
+const BASIC_DRAGGING_DATA_UUID = "BASIC_DRAGGING_DATA_UUID";
+const VALID_DRAG_TYPE = `text/renda; dragtype=projectasset; draggingdata=${BASIC_DRAGGING_DATA_UUID}`;
+
+Deno.test({
+	name: "Valid drag event",
+	fn() {
+		const {gui, uninstall} = createBasicGui();
+
+		try {
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
+			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
+			gui.onDragEnter(dragEvent);
+			assertEquals(gui.el.classList.contains("dragHovering"), true);
+			assertEquals(dragEvent.defaultPrevented, true);
+			assertEquals(dragEvent.dataTransfer?.dropEffect, "link");
+		} finally {
+			uninstall();
+		}
+	},
+});
+
+Deno.test({
+	name: "Valid drag event on disabled gui",
+	fn() {
+		const {gui, uninstall} = createBasicGui({
+			guiOpts: {
+				disabled: true,
+			},
+		});
+
+		try {
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
+			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
+			gui.onDragEnter(dragEvent);
+			assertEquals(gui.el.classList.contains("dragHovering"), false);
+			assertEquals(dragEvent.defaultPrevented, false);
+			assertEquals(dragEvent.dataTransfer?.dropEffect, "none");
+		} finally {
+			uninstall();
+		}
+	},
+});
+
+Deno.test({
+	name: "Invalid drag event",
+	fn() {
+		const {gui, uninstall} = createBasicGui();
+
+		try {
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
+			dragEvent.dataTransfer?.setData("text/renda; dragtype=rearrangingtreeview; rootuuid=someuuid", "");
+			gui.onDragEnter(dragEvent);
+			assertEquals(gui.el.classList.contains("dragHovering"), false);
+			assertEquals(dragEvent.defaultPrevented, false);
+			assertEquals(dragEvent.dataTransfer?.dropEffect, "none");
+		} finally {
+			uninstall();
+		}
+	},
+});
+
+/**
+ * @param {Object} options
+ * @param {boolean} [options.hasSupportedAssetType]
+ */
+function basicSetupForSupportedAssetTypes({
+	hasSupportedAssetType = true,
+} = {}) {
+	class SupportedLiveAsset {}
+	class NonSupportedLiveAsset {}
+	const {gui, uninstall, mockDragManager} = createBasicGui({
+		guiOpts: {
+			supportedAssetTypes: [SupportedLiveAsset],
+		},
+	});
+
+	const expectedLiveAssetConstructor = hasSupportedAssetType ? SupportedLiveAsset : NonSupportedLiveAsset;
+
+	stub(mockDragManager, "getDraggingData", uuid => {
+		if (uuid == BASIC_DRAGGING_DATA_UUID) {
+			/** @type {import("../../../../../../editor/src/windowManagement/contentWindows/ProjectContentWindow.js").DraggingProjectAssetData} */
+			return {
+				assetType: /** @type {typeof import("../../../../../../editor/src/assets/projectAssetType/ProjectAssetType.js").ProjectAssetType} */ ({
+					expectedLiveAssetConstructor,
+				}),
+				assetUuid: "someuuid",
+				dataPopulated: true,
+			};
+		}
+	});
+
+	return {
+		gui,
+		uninstall,
+	};
+}
+
+Deno.test({
+	name: "Invalid drag event because the asset type is not supported",
+	fn() {
+		const {gui, uninstall} = basicSetupForSupportedAssetTypes({
+			hasSupportedAssetType: false,
+		});
+
+		try {
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
+			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
+			gui.onDragEnter(dragEvent);
+			assertEquals(gui.el.classList.contains("dragHovering"), false);
+			assertEquals(dragEvent.defaultPrevented, false);
+			assertEquals(dragEvent.dataTransfer?.dropEffect, "none");
+		} finally {
+			uninstall();
+		}
+	},
+});
+
+Deno.test({
+	name: "Valid drag event with supportedAssetTypes",
+	fn() {
+		const {gui, uninstall} = basicSetupForSupportedAssetTypes();
+
+		try {
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
+			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
+			gui.onDragEnter(dragEvent);
+			assertEquals(gui.el.classList.contains("dragHovering"), true);
+			assertEquals(dragEvent.defaultPrevented, true);
+			assertEquals(dragEvent.dataTransfer?.dropEffect, "link");
+		} finally {
+			uninstall();
+		}
+	},
+});

--- a/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
+++ b/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
@@ -1,6 +1,6 @@
 import {assertEquals} from "std/testing/asserts.ts";
 import {stub} from "std/testing/mock.ts";
-import {FakeDragEvent} from "fake-dom/FakeDragEvent.js";
+import {DragEvent} from "/Users/Jesper/repositories/fake-dom/src/FakeDragEvent.js";
 import {createBasicGui} from "./shared.js";
 
 const BASIC_DRAGGING_DATA_UUID = "BASIC_DRAGGING_DATA_UUID";
@@ -12,8 +12,7 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);
@@ -35,8 +34,7 @@ Deno.test({
 		});
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -54,8 +52,7 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData("text/renda; dragtype=rearrangingtreeview; rootuuid=someuuid", "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -111,8 +108,7 @@ Deno.test({
 		});
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -130,8 +126,7 @@ Deno.test({
 		const {gui, uninstall} = basicSetupForSupportedAssetTypes();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);

--- a/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
+++ b/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
@@ -1,6 +1,6 @@
 import {assertEquals} from "std/testing/asserts.ts";
 import {stub} from "std/testing/mock.ts";
-import {DragEvent} from "/Users/Jesper/repositories/fake-dom/src/FakeDragEvent.js";
+import {FakeDragEvent} from "fake-dom/FakeDragEvent.js";
 import {createBasicGui} from "./shared.js";
 
 const BASIC_DRAGGING_DATA_UUID = "BASIC_DRAGGING_DATA_UUID";
@@ -12,7 +12,8 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			const dragEvent = new DragEvent("dragenter");
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);
@@ -34,7 +35,8 @@ Deno.test({
 		});
 
 		try {
-			const dragEvent = new DragEvent("dragenter");
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -52,7 +54,8 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			const dragEvent = new DragEvent("dragenter");
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
 			dragEvent.dataTransfer?.setData("text/renda; dragtype=rearrangingtreeview; rootuuid=someuuid", "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -108,7 +111,8 @@ Deno.test({
 		});
 
 		try {
-			const dragEvent = new DragEvent("dragenter");
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -126,7 +130,8 @@ Deno.test({
 		const {gui, uninstall} = basicSetupForSupportedAssetTypes();
 
 		try {
-			const dragEvent = new DragEvent("dragenter");
+			/** @type {DragEvent} */
+			const dragEvent = new FakeDragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);

--- a/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
+++ b/test/unit/editor/src/ui/DroppableGui/dragEvents.test.js
@@ -1,6 +1,6 @@
 import {assertEquals} from "std/testing/asserts.ts";
 import {stub} from "std/testing/mock.ts";
-import {FakeDragEvent} from "fake-dom/FakeDragEvent.js";
+import {DragEvent} from "fake-dom/FakeDragEvent.js";
 import {createBasicGui} from "./shared.js";
 
 const BASIC_DRAGGING_DATA_UUID = "BASIC_DRAGGING_DATA_UUID";
@@ -12,8 +12,7 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);
@@ -35,8 +34,7 @@ Deno.test({
 		});
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -54,8 +52,7 @@ Deno.test({
 		const {gui, uninstall} = createBasicGui();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData("text/renda; dragtype=rearrangingtreeview; rootuuid=someuuid", "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -111,8 +108,7 @@ Deno.test({
 		});
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), false);
@@ -130,8 +126,7 @@ Deno.test({
 		const {gui, uninstall} = basicSetupForSupportedAssetTypes();
 
 		try {
-			/** @type {DragEvent} */
-			const dragEvent = new FakeDragEvent("dragenter");
+			const dragEvent = new DragEvent("dragenter");
 			dragEvent.dataTransfer?.setData(VALID_DRAG_TYPE, "");
 			gui.onDragEnter(dragEvent);
 			assertEquals(gui.el.classList.contains("dragHovering"), true);

--- a/test/unit/editor/src/ui/DroppableGui/shared.js
+++ b/test/unit/editor/src/ui/DroppableGui/shared.js
@@ -150,6 +150,10 @@ export function createBasicGui({
 		},
 	});
 
+	const mockDragManager = /** @type {import("../../../../../../editor/src/misc/DragManager.js").DragManager} */ ({
+		getDraggingData(uuid) {},
+	});
+
 	const mockWindowManager = /** @type {import("../../../../../../editor/src/windowManagement/WindowManager.js").WindowManager} */ ({});
 
 	const liveAssetProjectAssetTypes = new Map(liveAssetProjectAssetTypeCombinations);
@@ -165,7 +169,7 @@ export function createBasicGui({
 	/** @type {import("../../../../../../editor/src/ui/DroppableGui.js").DroppableGuiDependencies} */
 	const dependencies = {
 		projectManager: mockProjectManager,
-		dragManager: /** @type {import("../../../../../../editor/src/misc/DragManager.js").DragManager} */ ({}),
+		dragManager: mockDragManager,
 		windowManager: mockWindowManager,
 		contextMenuManager: /** @type {import("../../../../../../editor/src/ui/contextMenus/ContextMenuManager.js").ContextMenuManager} */ ({}),
 		projectAssetTypeManager: mockProjectAssetTypeManager,
@@ -193,6 +197,7 @@ export function createBasicGui({
 		mockDefaultAssetLink,
 		mockLiveAsset,
 		mockProjectAsset,
+		mockDragManager,
 		mockWindowManager,
 		createEmbeddedAssetSpy,
 		getProjectAssetFromUuidOrEmbeddedAssetDataSyncSpy,


### PR DESCRIPTION
The `supportedAssetTypes` option of droppable guis initially required `ProjectAsset` to be provided in order to constrain droppable guis to only assets. But dropping anything other than assets wasn't actually working at all.
This change removes this requirement and instead dropping is always only constrained to assets.

Lack of typing also caused an error to be thrown in cases where the `supportedAssetTypes` option was an empty array. This should be fixed as well.

Fixes #32