### PR TITLE
fix: Cache puppeteer download in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,12 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      - name: Cache puppeteer
+        uses: actions/cache@v3
+        with:
+          key: puppeteer-${{ runner.os }}-${{ env.PUPPETEER_CHROMIUM_REVISION }}
+          path: ${{ env.PUPPETEER_DOWNLOAD_PATH }}
+
       - name: Install puppeteer
         run: PUPPETEER_PRODUCT=chrome deno run -A --unstable https://deno.land/x/puppeteer@14.1.1/install.ts
 


### PR DESCRIPTION
Fixes #36