### PR TITLE
fix: Use the correct casing for internal discovery paths

### DIFF
--- a/editor/dist/internalDiscovery/index.html
+++ b/editor/dist/internalDiscovery/index.html
@@ -2,7 +2,7 @@
 <html>
 	<head>
 		<!--discovery script tag-->
-		<script type="module" src="../src/Network/EditorConnections/InternalDiscovery/internalDiscovery.js"></script>
+		<script type="module" src="../../src/network/editorConnections/internalDiscovery/internalDiscovery.js"></script>
 	</head>
 	<body>
 	</body>

--- a/editor/scripts/build.js
+++ b/editor/scripts/build.js
@@ -55,7 +55,7 @@ function overrideDefines(definesFilePath, defines) {
 (async () => {
 	if (isDevBuild) {
 		setScriptSrc("../dist/index.html", "editor script tag", "../src/main.js");
-		setScriptSrc("../dist/internalDiscovery/index.html", "discovery script tag", "../src/Network/EditorConnections/InternalDiscovery/internalDiscovery.js");
+		setScriptSrc("../dist/internalDiscovery/index.html", "discovery script tag", "../../src/network/editorConnections/internalDiscovery/internalDiscovery.js");
 		try {
 			await Deno.remove("../dist/main.js");
 		} catch {
@@ -63,11 +63,11 @@ function overrideDefines(definesFilePath, defines) {
 		}
 	} else {
 		setScriptSrc("../dist/index.html", "editor script tag", "./js/main.js");
-		setScriptSrc("../dist/internalDiscovery/index.html", "discovery script tag", "./js/internalDiscovery.js");
+		setScriptSrc("../dist/internalDiscovery/index.html", "discovery script tag", "../js/internalDiscovery.js");
 		const bundle = await rollup({
 			input: [
 				"../src/main.js",
-				"../src/Network/EditorConnections/InternalDiscovery/internalDiscovery.js",
+				"../src/network/editorConnections/internalDiscovery/internalDiscovery.js",
 			],
 			plugins: [
 				overrideDefines("../src/editorDefines.js", defines),

--- a/src/Inspector/InternalDiscoveryManager.js
+++ b/src/Inspector/InternalDiscoveryManager.js
@@ -41,7 +41,7 @@ class InternalDiscoveryManager {
 		/** @type {Set<() => void>} */
 		this.onIframeLoadCbs = new Set();
 		this.iframe = document.createElement("iframe");
-		this.iframe.src = "/editor/dist/internalDiscovery";
+		this.iframe.src = "/editor/dist/internalDiscovery/index.html";
 		this.iframe.style.display = "none";
 		this.boundOnMessage = this._onIframeMessage.bind(this);
 		window.addEventListener("message", this.boundOnMessage);


### PR DESCRIPTION
There's still some errors in release builds that I'll fix later

Fixes #52