### PR TITLE
fix: Don't save contentWindowPersistentData when its empty

### DIFF
--- a/editor/src/projectSelector/ProjectManager.js
+++ b/editor/src/projectSelector/ProjectManager.js
@@ -130,10 +130,15 @@ export class ProjectManager {
 			this.fireOnProjectOpenEntryChangeCbs();
 		};
 
-		/** @type {(data: any) => Promise<void>} */
+		/** @type {(data: unknown[]) => Promise<void>} */
 		this.#boundSaveContentWindowPersistentData = async data => {
 			if (!this.localProjectSettings) return;
-			await this.localProjectSettings.set("contentWindowPersistentData", data);
+			const key = "contentWindowPersistentData";
+			if (data.length <= 0) {
+				await this.localProjectSettings.delete(key);
+			} else {
+				await this.localProjectSettings.set(key, data);
+			}
 		};
 
 		/** @type {Set<(entry: StoredProjectEntryAny) => any>} */

--- a/test/e2e/editor/shared/waitSeconds.js
+++ b/test/e2e/editor/shared/waitSeconds.js
@@ -1,0 +1,11 @@
+import {wait} from "../../../../src/util/Timeout.js";
+
+/**
+ * @param {Deno.TestContext} testContext
+ * @param {number} seconds
+ */
+export async function waitSeconds(testContext, seconds) {
+	await testContext.step("Waiting 5 seconds", async () => {
+		await wait(seconds * 1000);
+	});
+}


### PR DESCRIPTION
Fixes #80