### PR TITLE
feat(tasks): Add support for task environment variables

### DIFF
--- a/editor/src/assets/projectAssetType/ProjectAssetTypeTask.js
+++ b/editor/src/assets/projectAssetType/ProjectAssetTypeTask.js
@@ -5,6 +5,7 @@ import {ProjectAssetType} from "./ProjectAssetType.js";
  * @typedef TaskProjectAssetDiskData
  * @property {string} taskType
  * @property {unknown} [taskConfig]
+ * @property {Object<string, string>} [environmentVariables]
  */
 
 /**

--- a/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
+++ b/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
@@ -1,7 +1,7 @@
 import {createTreeViewStructure} from "../ui/propertiesTreeView/createStructureHelpers.js";
 import {PropertiesAssetContent} from "./PropertiesAssetContent.js";
 
-const environmentVariablesStructure = createTreeViewStructure({
+export const environmentVariablesStructure = createTreeViewStructure({
 	environmentVariables: {
 		type: "array",
 		guiOpts: {

--- a/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
+++ b/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
@@ -125,12 +125,18 @@ export class PropertiesAssetContentTask extends PropertiesAssetContent {
 			purpose: "fileStorage",
 		});
 		if (environmentVariablesValue?.environmentVariables) {
-			assetData.environmentVariables = {};
+			/** @type {Object<string, string>} */
+			const variables = {};
+			let hasItem = false;
 			for (const item of environmentVariablesValue.environmentVariables) {
 				// TODO: Handle undefined in the getValue() function from array guis #119
 				if (!item) continue;
 				if (!item.key) continue;
-				assetData.environmentVariables[item.key] = item.value || "";
+				variables[item.key] = item.value || "";
+				hasItem = true;
+			}
+			if (hasItem) {
+				assetData.environmentVariables = variables;
 			}
 		}
 		if (this.#currentConfigStructure) {

--- a/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
+++ b/editor/src/propertiesAssetContent/PropertiesAssetContentTask.js
@@ -143,7 +143,7 @@ export class PropertiesAssetContentTask extends PropertiesAssetContent {
 			const configData = this.taskConfigTree.getSerializableStructureValues(this.#currentConfigStructure, {
 				purpose: "fileStorage",
 			});
-			assetData.taskConfig = configData;
+			if (configData) assetData.taskConfig = configData;
 		}
 		await this.currentSelection[0].writeAssetData(assetData);
 	}

--- a/editor/src/tasks/environmentVariables.js
+++ b/editor/src/tasks/environmentVariables.js
@@ -1,0 +1,66 @@
+/**
+ * Recursively traverses down the taskConfig object and replaces variables
+ * of any string within the object with the value of that variable.
+ * Variables are indicated using a dollar sign ($) followed by the name of the variable.
+ *
+ * For example, the following object:
+ * ```js
+ * {
+ * 	foo: { bar: "$VAR1"},
+ * 	baz: "(this text is not replaced) $VAR2 (and neither is this)",
+ * }
+ * ```
+ * With the following environment variables:
+ * ```js
+ * {
+ * 	VAR1: "hello",
+ * 	VAR2: "world",
+ * }
+ * ```
+ * Will modify the object to be
+ * ```js
+ * {
+ * 	foo: { bar: "hello"},
+ * 	baz: "(this text is not replaced) world (and neither is this)",
+ * }
+ * ```
+ * The object is modified in place rather than being cloned.
+ * Circular references are not accounted for.
+ * @param {any} taskConfig
+ * @param {Object<string, string>} environmentVariables
+ */
+export function fillEnvironmentVariables(taskConfig, environmentVariables) {
+	if (taskConfig == null) return null;
+	if (typeof taskConfig == "object") {
+		if (Array.isArray(taskConfig)) {
+			for (const [i, entry] of taskConfig.entries()) {
+				if (typeof entry == "string") {
+					taskConfig[i] = fillEnvironmentVariablesString(entry, environmentVariables);
+				} else {
+					fillEnvironmentVariables(entry, environmentVariables);
+				}
+			}
+		} else {
+			for (const [key, value] of Object.entries(taskConfig)) {
+				if (typeof value == "string") {
+					taskConfig[key] = fillEnvironmentVariablesString(value, environmentVariables);
+				} else {
+					fillEnvironmentVariables(value, environmentVariables);
+				}
+			}
+		}
+	} else if (typeof taskConfig == "string") {
+		throw new Error("Applying environment variables to configs that are a single string is not supported.");
+	}
+}
+
+/**
+ * @param {string} str
+ * @param {Object<string, string>} environmentVariables
+ */
+function fillEnvironmentVariablesString(str, environmentVariables) {
+	for (const [name, value] of Object.entries(environmentVariables)) {
+		str = str.replaceAll("$" + name, value);
+	}
+	return str;
+}

--- a/editor/src/tasks/task/Task.js
+++ b/editor/src/tasks/task/Task.js
@@ -25,6 +25,8 @@
  */
 
 /**
+ * Options passed into {@linkcode Task.runTask}. This is generally only created
+ * by the task manager. Rather than being called directly.
  * @template TTaskConfig
  * @typedef RunTaskOptions
  * @property {TTaskConfig} config

--- a/test/unit/editor/src/assets/shared/createMockProjectAsset.js
+++ b/test/unit/editor/src/assets/shared/createMockProjectAsset.js
@@ -41,7 +41,7 @@ export function createMockProjectAsset({
 		},
 		async childEmbeddedAssetNeedsSave() {},
 		async readAssetData() {
-			return readAssetDataReturnValue;
+			return structuredClone(readAssetDataReturnValue);
 		},
 		async writeAssetData(fileData) {},
 		addEmbeddedChildLiveAsset(key, liveAsset) {

--- a/test/unit/editor/src/propertiesAssetContent/TaskPropertiesAssetContent.test.js
+++ b/test/unit/editor/src/propertiesAssetContent/TaskPropertiesAssetContent.test.js
@@ -1,20 +1,28 @@
 import "../../shared/initializeEditor.js";
 import {installFakeDocument, uninstallFakeDocument} from "fake-dom/FakeDocument.js";
-import {PropertiesAssetContentTask} from "../../../../../editor/src/propertiesAssetContent/PropertiesAssetContentTask.js";
+import {PropertiesAssetContentTask, environmentVariablesStructure} from "../../../../../editor/src/propertiesAssetContent/PropertiesAssetContentTask.js";
 import {createMockProjectAsset} from "../assets/shared/createMockProjectAsset.js";
 import {createTreeViewStructure} from "../../../../../editor/src/ui/propertiesTreeView/createStructureHelpers.js";
 import {Task} from "../../../../../editor/src/tasks/task/Task.js";
 import {assertEquals, assertInstanceOf} from "std/testing/asserts.ts";
 import {PropertiesTreeViewEntry} from "../../../../../editor/src/ui/propertiesTreeView/PropertiesTreeViewEntry.js";
 import {TextGui} from "../../../../../editor/src/ui/TextGui.js";
-import {assertSpyCalls, spy} from "std/testing/mock.ts";
+import {assertSpyCall, assertSpyCalls, spy} from "std/testing/mock.ts";
 
 /**
  * @param {object} options
  * @param {(typeof Task)[]} [options.extraTaskTypes]
+ * @param {Object<string, string>?} [options.environmentVariablesAssetData] The environment variable data stored in the asset on disk.
+ * @param {boolean} [options.useBasicEnvironmentVariables] If true, `environmentVariablesAssetData` gets replaced with basic data.
+ * @param {Object<string, string>?} [options.taskConfigAssetData] The task config data stored in the asset on disk.
+ * @param {boolean} [options.useBasicTaskConfig] If true, `taskConfigAssetData` gets replaced with basic data.
  */
 function basicSetup({
 	extraTaskTypes = [],
+	environmentVariablesAssetData = null,
+	useBasicEnvironmentVariables = false,
+	taskConfigAssetData = null,
+	useBasicTaskConfig = false,
 } = {}) {
 	const BASIC_TASK_TYPE = "namespace:tasktype";
 	class BasicTask extends Task {
@@ -45,10 +53,21 @@ function basicSetup({
 	/** @type {import("../../../../../editor/src/assets/projectAssetType/ProjectAssetTypeTask.js").TaskProjectAssetDiskData} */
 	const readAssetDataReturnValue = {
 		taskType: "namespace:tasktype",
-		taskConfig: {
-			foo: "bar",
-		},
 	};
+	if (useBasicEnvironmentVariables) {
+		readAssetDataReturnValue.environmentVariables = {
+			foo: "bar",
+		};
+	} else if (environmentVariablesAssetData) {
+		readAssetDataReturnValue.environmentVariables = environmentVariablesAssetData;
+	}
+	if (useBasicTaskConfig) {
+		readAssetDataReturnValue.taskConfig = {
+			foo: "bar",
+		};
+	} else if (taskConfigAssetData) {
+		readAssetDataReturnValue.taskConfig = taskConfigAssetData;
+	}
 
 	const {projectAsset: mockProjectAsset} = createMockProjectAsset({
 		readAssetDataReturnValue,
@@ -62,12 +81,68 @@ function basicSetup({
 }
 
 Deno.test({
+	name: "Loads environment variables from disk",
+	async fn() {
+		installFakeDocument();
+
+		try {
+			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicEnvironmentVariables: true,
+			});
+
+			await assetContent.selectionUpdated([mockProjectAsset]);
+
+			assertEquals(assetContent.environmentVariablesTree.getSerializableStructureValues(environmentVariablesStructure), {
+				environmentVariables: [
+					{
+						key: "foo",
+						value: "bar",
+					},
+				],
+			});
+		} finally {
+			uninstallFakeDocument();
+		}
+	},
+});
+
+Deno.test({
+	name: "Loads environment variables with partial data from disk",
+	async fn() {
+		installFakeDocument();
+
+		try {
+			const {assetContent, mockProjectAsset} = basicSetup({
+				environmentVariablesAssetData: {
+					foo: "",
+				},
+			});
+
+			await assetContent.selectionUpdated([mockProjectAsset]);
+
+			assertEquals(assetContent.environmentVariablesTree.getSerializableStructureValues(environmentVariablesStructure), {
+				environmentVariables: [
+					{
+						key: "foo",
+						value: "",
+					},
+				],
+			});
+		} finally {
+			uninstallFakeDocument();
+		}
+	},
+});
+
+Deno.test({
 	name: "Loads the task config from disk",
 	async fn() {
 		installFakeDocument();
 
 		try {
-			const {assetContent, mockProjectAsset} = basicSetup();
+			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicTaskConfig: true,
+			});
 
 			await assetContent.selectionUpdated([mockProjectAsset]);
 
@@ -91,6 +166,7 @@ Deno.test({
 				static type = "namespace:noconfigtasktype";
 			}
 			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicTaskConfig: true,
 				extraTaskTypes: [NoConfigTask],
 			});
 
@@ -112,15 +188,119 @@ Deno.test({
 });
 
 Deno.test({
+	name: "Environment variables ui changes are saved to disk",
+	async fn() {
+		installFakeDocument();
+
+		try {
+			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicEnvironmentVariables: true,
+			});
+
+			await assetContent.selectionUpdated([mockProjectAsset]);
+			const writeAssetDataSpy = spy(mockProjectAsset, "writeAssetData");
+
+			const variablesTreeView = assetContent.environmentVariablesTree.getSerializableStructureEntry("environmentVariables");
+			const firstArrayItemGui = variablesTreeView.gui.valueItems[0].gui;
+			const valueGui = firstArrayItemGui.treeView.getSerializableStructureEntry("value").gui;
+			valueGui.setValue("baz");
+			valueGui.fireOnChangeCbs();
+
+			assertSpyCalls(writeAssetDataSpy, 1);
+			assertSpyCall(writeAssetDataSpy, 0, {
+				args: [
+					{
+						taskType: "namespace:tasktype",
+						taskConfig: undefined,
+						environmentVariables: {
+							foo: "baz",
+						},
+					},
+				],
+			});
+		} finally {
+			uninstallFakeDocument();
+		}
+	},
+});
+
+Deno.test({
+	name: "Empty environment variables ui changes are not saved to disk",
+	async fn() {
+		installFakeDocument();
+
+		try {
+			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicEnvironmentVariables: true,
+			});
+
+			await assetContent.selectionUpdated([mockProjectAsset]);
+			const writeAssetDataSpy = spy(mockProjectAsset, "writeAssetData");
+
+			const variablesTreeView = assetContent.environmentVariablesTree.getSerializableStructureEntry("environmentVariables");
+			const firstArrayItemGui = variablesTreeView.gui.valueItems[0].gui;
+			const keyGui = firstArrayItemGui.treeView.getSerializableStructureEntry("key").gui;
+			const valueGui = firstArrayItemGui.treeView.getSerializableStructureEntry("value").gui;
+
+			// Empty value
+			valueGui.setValue("");
+			valueGui.fireOnChangeCbs();
+			assertSpyCalls(writeAssetDataSpy, 1);
+			assertSpyCall(writeAssetDataSpy, 0, {
+				args: [
+					{
+						taskType: "namespace:tasktype",
+						taskConfig: undefined,
+						environmentVariables: {
+							foo: "",
+						},
+					},
+				],
+			});
+
+			// Empty key
+			keyGui.setValue("");
+			valueGui.setValue("value");
+			valueGui.fireOnChangeCbs();
+			assertSpyCalls(writeAssetDataSpy, 2);
+			assertSpyCall(writeAssetDataSpy, 1, {
+				args: [
+					{
+						taskType: "namespace:tasktype",
+						taskConfig: undefined,
+					},
+				],
+			});
+
+			// Empty key and empty value
+			valueGui.setValue("");
+			valueGui.fireOnChangeCbs();
+			assertSpyCalls(writeAssetDataSpy, 3);
+			assertSpyCall(writeAssetDataSpy, 2, {
+				args: [
+					{
+						taskType: "namespace:tasktype",
+						taskConfig: undefined,
+					},
+				],
+			});
+		} finally {
+			uninstallFakeDocument();
+		}
+	},
+});
+
+Deno.test({
 	name: "Config ui changes are saved to disk",
 	async fn() {
 		installFakeDocument();
 
 		try {
-			const {assetContent, mockProjectAsset} = basicSetup();
+			const {assetContent, mockProjectAsset} = basicSetup({
+				useBasicTaskConfig: true,
+			});
 
 			await assetContent.selectionUpdated([mockProjectAsset]);
-			mockProjectAsset.writeAssetData = async () => {};
 			const writeAssetDataSpy = spy(mockProjectAsset, "writeAssetData");
 
 			const fooNode = assetContent.taskConfigTree.children[0];

--- a/test/unit/editor/src/tasks/TaskManager.test.js
+++ b/test/unit/editor/src/tasks/TaskManager.test.js
@@ -396,7 +396,7 @@ Deno.test({
 				},
 			},
 		});
-		/** @type {Map<import("../../../../../src/mod.js").UuidString, import("../../../../../editor/src/assets/ProjectAsset.js").ProjectAssetAny} */
+		/** @type {Map<import("../../../../../src/mod.js").UuidString, import("../../../../../editor/src/assets/ProjectAsset.js").ProjectAssetAny>} */
 		const uuidProjectAssets = new Map();
 		uuidProjectAssets.set(TOUCHED_ASSET_UUID, childProjectAsset);
 		const {cleanup} = basicTaskRunningSetup({

--- a/test/unit/editor/src/tasks/environmentVariables.test.js
+++ b/test/unit/editor/src/tasks/environmentVariables.test.js
@@ -1,0 +1,87 @@
+import {assertEquals, assertThrows} from "std/testing/asserts.ts";
+import {fillEnvironmentVariables} from "../../../../../editor/src/tasks/environmentVariables.js";
+
+Deno.test({
+	name: "Basic replacement",
+	fn() {
+		const config = {
+			foo: {bar: "$VAR1"},
+			baz: "(this text is not replaced) $VAR2 (and neither is this)",
+		};
+
+		fillEnvironmentVariables(config, {
+			VAR1: "hello",
+			VAR2: "world",
+		});
+
+		assertEquals(config, {
+			foo: {bar: "hello"},
+			baz: "(this text is not replaced) world (and neither is this)",
+		});
+	},
+});
+
+Deno.test({
+	name: "Nested arrays and objects",
+	fn() {
+		const config = {
+			arr: [
+				{
+					a: "$FOO_VAR",
+					b: [
+						"$BAR_VAR",
+						{
+							c: "$FOO_VAR",
+						},
+					],
+				},
+				{
+					a: "$BAR_VAR",
+					b: [
+						"$FOO_VAR",
+						{
+							c: "$BAR_VAR",
+						},
+					],
+				},
+			],
+		};
+
+		fillEnvironmentVariables(config, {
+			FOO_VAR: "foo",
+			BAR_VAR: "bar",
+		});
+
+		assertEquals(config, {
+			arr: [
+				{
+					a: "foo",
+					b: [
+						"bar",
+						{
+							c: "foo",
+						},
+					],
+				},
+				{
+					a: "bar",
+					b: [
+						"foo",
+						{
+							c: "bar",
+						},
+					],
+				},
+			],
+		});
+	},
+});
+
+Deno.test({
+	name: "Replace string only",
+	fn() {
+		assertThrows(() => {
+			fillEnvironmentVariables("string", {});
+		}, Error, "Applying environment variables to configs that are a single string is not supported.");
+	},
+});


### PR DESCRIPTION
This adds ui for modifying task environment variables and applies the environment variables to the task config.
Using environment variables for config properties other than strings is not supported yet. Though you might be able to manually edit the contents of task assets and replaced for instance boolean with a string that contains an environment variable.
Though these strings are not automatically replaced with the correct type. So tasks expecting a boolean might misinterpret a string containing `"false"` as a truthy value.

Fixes #62