### PR TITLE
fix: Use a single connection for IndexedDbUtil

### DIFF
--- a/src/util/IndexedDbUtil.js
+++ b/src/util/IndexedDbUtil.js
@@ -23,6 +23,16 @@ export class IndexedDbUtil {
 			}
 		};
 		this.#dbPromise = this.#promisifyRequest(dbRequest);
+		this.#initDb();
+	}
+
+	async #initDb() {
+		const db = await this.#dbPromise;
+		db.onversionchange = e => {
+			if (e.newVersion == null) {
+				db.close();
+			}
+		};
 	}
 
 	/**

--- a/test/unit/editor/shared/FakeIndexedDbUtil.js
+++ b/test/unit/editor/shared/FakeIndexedDbUtil.js
@@ -107,7 +107,6 @@ export class IndexedDbUtil {
 
 	constructor(dbName = "keyValuesDb", {
 		objectStoreNames = ["keyValues"],
-		enableLocalStorageFallback = false,
 	} = {}) {
 		this.#dbName = dbName;
 


### PR DESCRIPTION
We were opening a new connection for every db request. This change makes it open only a single one and reuse that for every transaction.
When the connection gets garbage collected browsers should automatically close it as far as I can tell.
This change also ensures that the connection is closed when a database is deleted.

Fixes #22