### PR TITLE
feat: Don't change selection when dragging assets

### DIFF
--- a/editor/src/ui/TreeView.js
+++ b/editor/src/ui/TreeView.js
@@ -1228,8 +1228,15 @@ export class TreeView {
 		this.updateDataRenameValue();
 	}
 
-	focus() {
-		this.rowEl.focus();
+	/**
+	 * Checks if the root treeview of this structure has focus within, and if not,
+	 * focuses on this treeview.
+	 */
+	focusIfNotFocused() {
+		const root = this.findRoot();
+		if (!root.hasFocusWithin) {
+			this.rowEl.focus();
+		}
 	}
 
 	updateDataRenameValue() {

--- a/editor/src/ui/TreeView.js
+++ b/editor/src/ui/TreeView.js
@@ -162,6 +162,10 @@ export class TreeView {
 	/** @type {import("../keyboardShortcuts/ShorcutConditionValueSetter.js").ShorcutConditionValueSetter<boolean>?} */
 	#focusSelectedShortcutCondition = null;
 
+	/** @type {HTMLElement?} */
+	#focusElBeforeDragStart = null;
+	#lastFocusInTime = 0;
+
 	/**
 	 * @param {TreeViewInitData} data
 	 */
@@ -643,9 +647,11 @@ export class TreeView {
 		if (draggable) {
 			this.rowEl.addEventListener("dragstart", this.#boundDragStart);
 			this.rowEl.addEventListener("dragend", this.#boundDragEnd);
+			this.rowEl.addEventListener("focusin", this.#onDraggableFocusIn);
 		} else {
 			this.rowEl.removeEventListener("dragstart", this.#boundDragStart);
 			this.rowEl.removeEventListener("dragend", this.#boundDragEnd);
+			this.rowEl.removeEventListener("focusin", this.#onDraggableFocusIn);
 		}
 	}
 
@@ -662,6 +668,9 @@ export class TreeView {
 	 * @param {DragEvent} e
 	 */
 	#onDragStartEvent(e) {
+		if (this.#focusElBeforeDragStart && performance.now() - this.#lastFocusInTime < 500) {
+			this.#focusElBeforeDragStart.focus();
+		}
 		const root = this.findRoot();
 		/** @type {Set<TreeView>} */
 		const selectedItems = new Set();
@@ -1311,6 +1320,7 @@ export class TreeView {
 	}
 
 	/**
+	 * Event registered on the root when the treeview is selectable.
 	 * @param {FocusEvent} e
 	 */
 	#onFocusIn = e => {
@@ -1318,10 +1328,24 @@ export class TreeView {
 	};
 
 	/**
+	 * Event registered on the root when the treeview is selectable.
 	 * @param {FocusEvent} e
 	 */
 	#onFocusOut = e => {
 		this.#handleFocusWithinChange(e.relatedTarget);
+	};
+
+	/**
+	 * Same as `onFocusIn`, except this event is only registered when the treeview
+	 * is draggable. This event is registered for all treeviews rather than just the root.
+	 * @param {FocusEvent} e
+	 */
+	#onDraggableFocusIn = e => {
+		const lastFocusEl = e.relatedTarget;
+		if (lastFocusEl instanceof HTMLElement) {
+			this.#focusElBeforeDragStart = lastFocusEl;
+			this.#lastFocusInTime = performance.now();
+		}
 	};
 
 	/**

--- a/editor/src/windowManagement/contentWindows/ContentWindowBuiltInAssets.js
+++ b/editor/src/windowManagement/contentWindows/ContentWindowBuiltInAssets.js
@@ -143,7 +143,7 @@ export class ContentWindowBuiltInAssets extends ContentWindow {
 	focusWithinChange(hasFocus) {
 		if (hasFocus) {
 			if (this.treeView.children.length > 0) {
-				this.treeView.children[0].focus();
+				this.treeView.children[0].focusIfNotFocused();
 			}
 		}
 	}

--- a/editor/src/windowManagement/contentWindows/ContentWindowOutliner.js
+++ b/editor/src/windowManagement/contentWindows/ContentWindowOutliner.js
@@ -254,7 +254,7 @@ export class ContentWindowOutliner extends ContentWindow {
 	 */
 	focusWithinChange(hasFocus) {
 		if (hasFocus) {
-			this.treeView.focus();
+			this.treeView.focusIfNotFocused();
 		}
 	}
 

--- a/editor/src/windowManagement/contentWindows/ContentWindowProject.js
+++ b/editor/src/windowManagement/contentWindows/ContentWindowProject.js
@@ -539,7 +539,7 @@ export class ContentWindowProject extends ContentWindow {
 	 */
 	focusWithinChange(hasFocus) {
 		if (hasFocus) {
-			this.treeView.focus();
+			this.treeView.focusIfNotFocused();
 		}
 	}
 


### PR DESCRIPTION
Calling focus() on an element seems to prevent dragstart events. So this change ensures treeviews are only focused when they don't have focus yet. Dragging an element also causes that element to get focus, so calling focus again isn't necessary.

However, this focus event causes the current selection to change, and as a result the properties window content is changed. To prevent this, we revert the focus to the previous element the moment a treeview is dragged. This causes a brief flicker while the focus is changed back and forth. Unfortunately there's little that can be done about this in regards to :focus-within css selectors. But the flickering of the content of the properties window could potentially be fixed in a follow up PR.

Fixes #133