### PR TITLE
fix: Don't make writeAssetData fill up the queue when calling frequently

### DIFF
--- a/editor/devSocket/src/BuiltInAssetManager.js
+++ b/editor/devSocket/src/BuiltInAssetManager.js
@@ -30,8 +30,6 @@ export class BuiltInAssetManager {
 		/** @private */
 		this.loadAssetSettingsInstance = new SingleInstancePromise(async () => {
 			await this.loadAssetSettingsFn();
-		}, {
-			once: false,
 		});
 		this.assetSettingsLoaded = false;
 		/** @type {Map<import("../../../src/util/mod.js").UuidString, import("../../src/assets/AssetSettingsDiskTypes.js").AssetSettingsAssetDiskData>}*/

--- a/editor/devSocket/src/BuiltInAssetManager.js
+++ b/editor/devSocket/src/BuiltInAssetManager.js
@@ -31,7 +31,6 @@ export class BuiltInAssetManager {
 		this.loadAssetSettingsInstance = new SingleInstancePromise(async () => {
 			await this.loadAssetSettingsFn();
 		}, {
-			run: false,
 			once: false,
 		});
 		this.assetSettingsLoaded = false;

--- a/editor/src/assets/AssetManager.js
+++ b/editor/src/assets/AssetManager.js
@@ -140,8 +140,8 @@ export class AssetManager {
 			await this.loadAssetSettingsInstanceFn();
 		}, {
 			once: false,
-			run: true,
 		});
+		this.loadAssetSettingsInstance.run();
 	}
 
 	destructor() {

--- a/editor/src/assets/AssetManager.js
+++ b/editor/src/assets/AssetManager.js
@@ -138,8 +138,6 @@ export class AssetManager {
 		this.loadAssetSettingsFromUserGesture = false;
 		this.loadAssetSettingsInstance = new SingleInstancePromise(async () => {
 			await this.loadAssetSettingsInstanceFn();
-		}, {
-			once: false,
 		});
 		this.loadAssetSettingsInstance.run();
 	}

--- a/editor/src/assets/BuiltInAssetManager.js
+++ b/editor/src/assets/BuiltInAssetManager.js
@@ -66,7 +66,8 @@ export class BuiltInAssetManager {
 				asset?.destructor();
 				this.assets.delete(uuid);
 			}
-		}, {run: true, once: false});
+		}, {once: false});
+		this.loadAssetsInstance.run();
 	}
 
 	/**

--- a/editor/src/assets/BuiltInAssetManager.js
+++ b/editor/src/assets/BuiltInAssetManager.js
@@ -66,7 +66,7 @@ export class BuiltInAssetManager {
 				asset?.destructor();
 				this.assets.delete(uuid);
 			}
-		}, {once: false});
+		});
 		this.loadAssetsInstance.run();
 	}
 

--- a/editor/src/assets/BuiltInAssetManager.js
+++ b/editor/src/assets/BuiltInAssetManager.js
@@ -83,7 +83,7 @@ export class BuiltInAssetManager {
 				}
 			});
 			devSocket.addListener("builtInAssetListUpdate", () => {
-				this.loadAssetsInstance.run(true);
+				this.loadAssetsInstance.run();
 			});
 		}
 	}

--- a/editor/src/assets/ProjectAsset.js
+++ b/editor/src/assets/ProjectAsset.js
@@ -132,7 +132,7 @@ export class ProjectAsset {
 		/** @private @type {Map<string, WeakRef<Object>>} */
 		this.previousLiveAssets = new Map();
 
-		this.initInstance = new SingleInstancePromise(async () => await this.init());
+		this.initInstance = new SingleInstancePromise(async () => await this.init(), {once: true});
 		this.initInstance.run();
 
 		/**

--- a/editor/src/assets/ProjectAsset.js
+++ b/editor/src/assets/ProjectAsset.js
@@ -67,6 +67,8 @@ export class ProjectAsset {
 	/** @type {Set<() => void>} */
 	#onLiveAssetNeedsReplacementCbs = new Set();
 
+	#writeAssetDataInstance;
+
 	/**
 	 * @param {import("./AssetManager.js").AssetManager} assetManager
 	 * @param {import("./ProjectAssetTypeManager.js").ProjectAssetTypeManager} assetTypeManager
@@ -134,6 +136,8 @@ export class ProjectAsset {
 
 		this.initInstance = new SingleInstancePromise(async () => await this.init(), {once: true});
 		this.initInstance.run();
+
+		this.#writeAssetDataInstance = new SingleInstancePromise(this.#writeAssetDataImpl);
 
 		/**
 		 * Whenever {@linkcode RecursionTracker.getLiveAssetData} is called with
@@ -640,9 +644,16 @@ export class ProjectAsset {
 	}
 
 	/**
-	 * Writes asset data to disk based on the current live asset. Note that if
-	 * the live asset does not exist, it will be created by reading from disk
-	 * first and then writing the result again. So if `liveAssetNeedsReplacement`
+	 * Writes asset data to disk based on the current live asset.
+	 *
+	 * If a promise of writing data is currently pending, the system will wait
+	 * for the promise to be resolved before writing the next one. Only a single
+	 * promise will be queued, meaning that if you call this very frequently, some
+	 * data may not be written to disk, only the last call will be written to disk
+	 * in that case.
+	 *
+	 * Note that if the live asset does not exist, it will be created by reading from
+	 * disk first and then writing the result again. So if `liveAssetNeedsReplacement`
 	 * has been triggered, either by this asset or by one of it's child assets,
 	 * this will essentially read and write the same data. To prevent this,
 	 * make sure you call `saveLiveAssetData` before `liveAssetNeedsReplacement`.
@@ -716,11 +727,25 @@ export class ProjectAsset {
 	}
 
 	/**
+	 * Writes asset data to disk. The provided data is slightly modified depending
+	 * on some static properties set by the project asset type.
+	 *
+	 * If a promise of writing data is currently pending, the system will wait
+	 * for the promise to be resolved before writing the next one. Only a single
+	 * promise will be queued, meaning that if you call this very frequently, some
+	 * data may not be written to disk, only the last call will be written to disk
+	 * in that case.
 	 * @param {FileDataType} fileData
 	 */
 	async writeAssetData(fileData) {
 		await this.waitForInit();
+		await this.#writeAssetDataInstance.run(fileData);
+	}
 
+	/**
+	 * @param {FileDataType} fileData
+	 */
+	#writeAssetDataImpl = async fileData => {
 		if (!this.projectAssetTypeConstructorSync) {
 			throw new Error("Unable to write asset data without a ProjectAssetType");
 		}
@@ -757,7 +782,7 @@ export class ProjectAsset {
 			const fileDataBlob = /** @type {BlobPart} */ (fileData);
 			await this.fileSystem.writeFile(this.path, fileDataBlob);
 		}
-	}
+	};
 
 	/**
 	 * Same as {@linkcode readAssetData} but returns the data synchronously

--- a/editor/src/componentGizmos/gizmos/ComponentGizmosCamera.js
+++ b/editor/src/componentGizmos/gizmos/ComponentGizmosCamera.js
@@ -17,7 +17,7 @@ export class ComponentGizmosCamera extends ComponentGizmos {
 		super(...args);
 
 		this.debugClusterBounds = false;
-		this.updateClusterBoundsInstance = new SingleInstancePromise(this.updateClusterBounds.bind(this), {once: false});
+		this.updateClusterBoundsInstance = new SingleInstancePromise(this.updateClusterBounds.bind(this));
 	}
 
 	componentPropertyChanged() {

--- a/editor/src/network/DevSocketManager.js
+++ b/editor/src/network/DevSocketManager.js
@@ -21,11 +21,11 @@ export class DevSocketManager {
 
 		this.tryConnectionOnceInstance = new SingleInstancePromise(async () => {
 			return await this.tryConnectionOnceFn();
-		}, {once: false});
+		});
 
 		this.tryConnectionMultipleInstance = new SingleInstancePromise(async () => {
 			return await this.tryConnectionMultipleFn();
-		}, {once: false});
+		});
 
 		this.tryConnectionOnce();
 	}

--- a/editor/src/projectSelector/ProjectManager.js
+++ b/editor/src/projectSelector/ProjectManager.js
@@ -152,8 +152,6 @@ export class ProjectManager {
 
 		this.loadEditorConnectionsAllowIncomingInstance = new SingleInstancePromise(async () => {
 			await this.loadEditorConnectionsAllowIncoming();
-		}, {
-			once: false,
 		});
 	}
 

--- a/editor/src/projectSelector/ProjectSettingsManager.js
+++ b/editor/src/projectSelector/ProjectSettingsManager.js
@@ -17,7 +17,7 @@ export class ProjectSettingsManager {
 		this.onFileCreatedCbs = new Set();
 
 		this.isLoadingFromUserGesture = false;
-		this.loadInstance = new SingleInstancePromise(async () => await this.loadFn());
+		this.loadInstance = new SingleInstancePromise(async () => await this.loadFn(), {once: true});
 		this.load(fromUserGesture);
 	}
 

--- a/editor/src/propertiesAssetContent/PropertiesAssetContentMaterial.js
+++ b/editor/src/propertiesAssetContent/PropertiesAssetContentMaterial.js
@@ -17,8 +17,7 @@ import {SingleInstancePromise} from "../../../src/util/SingleInstancePromise.js"
  * @extends {PropertiesAssetContent<import("../assets/projectAssetType/ProjectAssetTypeMaterial.js").ProjectAssetTypeMaterial>}
  */
 export class PropertiesAssetContentMaterial extends PropertiesAssetContent {
-	/** @type {SingleInstancePromise<void>?} */
-	#loadAssetInstance = null;
+	#loadAssetInstance;
 	/**
 	 * @param {ConstructorParameters<typeof PropertiesAssetContent>} args
 	 */
@@ -86,7 +85,6 @@ export class PropertiesAssetContentMaterial extends PropertiesAssetContent {
 	}
 
 	async waitForAssetLoad() {
-		if (!this.#loadAssetInstance) return;
 		await this.#loadAssetInstance.waitForFinish();
 	}
 
@@ -105,9 +103,7 @@ export class PropertiesAssetContentMaterial extends PropertiesAssetContent {
 	 */
 	async selectionUpdated(selectedMaterials) {
 		super.selectionUpdated(selectedMaterials);
-		if (this.#loadAssetInstance) {
-			await this.#loadAssetInstance.run();
-		}
+		await this.#loadAssetInstance.run();
 	}
 
 	async loadMapValues() {

--- a/editor/src/propertiesAssetContent/PropertiesAssetContentMaterial.js
+++ b/editor/src/propertiesAssetContent/PropertiesAssetContentMaterial.js
@@ -51,7 +51,7 @@ export class PropertiesAssetContentMaterial extends PropertiesAssetContent {
 
 		this.#loadAssetInstance = new SingleInstancePromise(async () => {
 			await this.loadAssetFn();
-		}, {once: false});
+		});
 
 		this.mapValuesTreeView = materialTree.addCollapsable("map values");
 

--- a/editor/src/util/fileSystems/FsaEditorFileSystem.js
+++ b/editor/src/util/fileSystems/FsaEditorFileSystem.js
@@ -40,7 +40,7 @@ export class FsaEditorFileSystem extends EditorFileSystem {
 			kind: "directory",
 			children: new Map(),
 		};
-		this.updateWatchTreeInstance = new SingleInstancePromise(async () => await this.updateWatchTree(), {once: false});
+		this.updateWatchTreeInstance = new SingleInstancePromise(async () => await this.updateWatchTree());
 		/** @type {Map<string, Set<CurrentlyGettingFileCallbackData>>} */
 		this.currentlyGettingFileCbs = new Map(); // <path, Set<cb>>
 

--- a/editor/src/util/fileSystems/FsaEditorFileSystem.js
+++ b/editor/src/util/fileSystems/FsaEditorFileSystem.js
@@ -46,7 +46,7 @@ export class FsaEditorFileSystem extends EditorFileSystem {
 
 		/** @type {Set<PermissionGrantedListener>} */
 		this.onPermissionGrantedListeners = new Set();
-		this.updateWatchTreeInstance.run(true);
+		this.updateWatchTreeInstance.run();
 	}
 
 	static async openUserDir() {
@@ -455,7 +455,7 @@ export class FsaEditorFileSystem extends EditorFileSystem {
 	 * @override
 	 */
 	suggestCheckExternalChanges() {
-		this.updateWatchTreeInstance.run(true);
+		this.updateWatchTreeInstance.run();
 	}
 
 	async updateWatchTree() {

--- a/src/assets/AssetBundle.js
+++ b/src/assets/AssetBundle.js
@@ -19,7 +19,7 @@ export class AssetBundle {
 		/** @type {Set<OnProgressCallback>} */
 		this.onProgressCbs = new Set();
 
-		this.downloadInstance = new SingleInstancePromise(async () => await this.downloadLogic());
+		this.downloadInstance = new SingleInstancePromise(async () => await this.downloadLogic(), {once: true});
 		this.headerWait = new PromiseWaitHelper();
 
 		this.downloadBuffer = null;

--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -8,7 +8,7 @@ export class SingleInstancePromise {
 	 * @param {boolean} [opts.once] If true, the function will only be run once. Repeated calls will return the first result.
 	 */
 	constructor(promiseFn, {
-		once = true,
+		once = false,
 	} = {}) {
 		this.once = once;
 		this.promiseFn = promiseFn;

--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -20,17 +20,17 @@ export class SingleInstancePromise {
 	}
 
 	/**
-	 * Runs the function.
-	 * Calling this many times with `repeatIfRunning` set to true will not cause the promise to
-	 * run many times. I.e., jobs do not get queued indefinitely, only twice.
-	 * @param {boolean} repeatIfRunning If true, the function will run again when the first run is done.
+	 * Runs the function. If the function is already running,the call will be
+	 * queued once. Ensuring that the last call is always run. If this function
+	 * is called many times while it is already running, only the last call
+	 * will be executed.
 	 * @returns {Promise<TReturn>}
 	 */
-	async run(repeatIfRunning = false) {
+	async run() {
 		if (this.isRunning) {
-			if (repeatIfRunning && !this.once) {
+			if (!this.once) {
 				await new Promise(r => this.onRunFinishCbs.add(r));
-				return await this.run(false);
+				return await this.run();
 			} else {
 				return await new Promise(r => this.onRunFinishCbs.add(r));
 			}

--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -74,6 +74,8 @@ export class SingleInstancePromise {
 			const result = await this.promiseFn(...lastEntry.args);
 			this._isEmptyingQueue = false;
 			this.hasRun = true;
+			this._onFinishCbs.forEach(cb => cb());
+			this._onFinishCbs.clear();
 
 			if (this.once) {
 				this._onceReturnValue = result;

--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -6,11 +6,9 @@ export class SingleInstancePromise {
 	 * @param {() => Promise<TReturn>} promiseFn
 	 * @param {object} opts
 	 * @param {boolean} [opts.once] If true, the function will only be run once. Repeated calls will return the first result.
-	 * @param {boolean} [opts.run] If true, the function will run immediately.
 	 */
 	constructor(promiseFn, {
 		once = true,
-		run = false,
 	} = {}) {
 		this.once = once;
 		this.promiseFn = promiseFn;
@@ -19,8 +17,6 @@ export class SingleInstancePromise {
 		this.onceReturnValue = undefined;
 		/** @type {Set<(result: TReturn) => void>} */
 		this.onRunFinishCbs = new Set();
-
-		if (run) this.run();
 	}
 
 	/**

--- a/test/unit/shared/asserts.js
+++ b/test/unit/shared/asserts.js
@@ -1,5 +1,6 @@
-import {AssertionError} from "std/testing/asserts.ts";
+import {AssertionError, assert} from "std/testing/asserts.ts";
 import {Mat4, Vec2, Vec3, Vec4} from "../../../src/mod.js";
+import {waitForMicrotasks as waitForMicrotasksFn} from "./waitForMicroTasks.js";
 
 /**
  * Make an assertion that `actual` and `expected` are almost numbers.
@@ -138,4 +139,20 @@ export function assertMatAlmostEquals(actual, expected, tolerance = 0.00001, msg
 		}
 		assertAlmostEquals(array1[i], array2[i], tolerance, message);
 	}
+}
+
+/**
+ * @param {Promise<any>} promise
+ * @param {boolean} expected
+ * @param {boolean} waitForMicrotasks
+ */
+export async function assertPromiseResolved(promise, expected, waitForMicrotasks = true) {
+	let resolved = false;
+	(async () => {
+		await promise;
+		resolved = true;
+	})();
+	if (waitForMicrotasks) await waitForMicrotasksFn();
+	const msg = expected ? "Expected the promise to be resolved" : "Expected the promise to not be resolved";
+	assert(resolved == expected, msg);
 }

--- a/test/unit/shared/asserts.test.js
+++ b/test/unit/shared/asserts.test.js
@@ -1,6 +1,6 @@
-import {assertThrows} from "std/testing/asserts.ts";
+import {assertRejects, assertThrows} from "std/testing/asserts.ts";
 import {Mat4, Vec2, Vec3, Vec4} from "../../../src/mod.js";
-import {assertAlmostEquals, assertMatAlmostEquals, assertVecAlmostEquals} from "./asserts.js";
+import {assertAlmostEquals, assertMatAlmostEquals, assertPromiseResolved, assertVecAlmostEquals} from "./asserts.js";
 
 Deno.test({
 	name: "assertAlmostEquals() doesn't throw",
@@ -189,5 +189,32 @@ Deno.test({
 		assertThrows(() => {
 			assertMatAlmostEquals(/** @type {any} */(null), new Mat4());
 		});
+	},
+});
+
+Deno.test({
+	name: "assertPromise resolved true",
+	async fn() {
+		const promise = new Promise(r => {
+			setTimeout(r, 0);
+		});
+		await promise;
+		await assertPromiseResolved(promise, true);
+
+		await assertRejects(async () => {
+			await assertPromiseResolved(promise, false);
+		}, Error, "Expected the promise to not be resolved");
+	},
+});
+
+Deno.test({
+	name: "assertPromise resolved false",
+	async fn() {
+		const promise = new Promise(r => {});
+		await assertPromiseResolved(promise, false);
+
+		await assertRejects(async () => {
+			await assertPromiseResolved(promise, true);
+		}, Error, "Expected the promise to be resolved");
 	},
 });

--- a/test/unit/src/util/SingleInstancePromise.js
+++ b/test/unit/src/util/SingleInstancePromise.js
@@ -1,0 +1,32 @@
+import {assertEquals} from "std/testing/asserts.ts";
+import {assertSpyCall, assertSpyCalls, spy} from "std/testing/mock.ts";
+import {SingleInstancePromise} from "../../../../src/mod.js";
+
+Deno.test({
+	name: "Single run",
+	async fn() {
+		const instance = new SingleInstancePromise((/** @type {number} */ x) => {
+			return x;
+		});
+
+		const result = await instance.run(1337);
+		assertEquals(result, 1337);
+	},
+});
+
+Deno.test({
+	name: "once: true, only runs once",
+	async fn() {
+		const fn = spy((/** @type {number} */ x) => x);
+		const instance = new SingleInstancePromise(fn, {once: true});
+
+		await instance.run(123);
+		await instance.run(456);
+
+		assertSpyCalls(fn, 1);
+		assertSpyCall(fn, 0, {
+			args: [123],
+			returned: 123,
+		});
+	},
+});


### PR DESCRIPTION
Fixes #95