### PR TITLE
fix(core): Don't adjust local matrix on children when changing parent transformation

### DIFF
--- a/src/core/Entity.js
+++ b/src/core/Entity.js
@@ -101,6 +101,15 @@ export class Entity {
 
 		/** @private */
 		this.worldPosRotScaleDirty = false;
+		/**
+		 * We listen for changes on the world vectors and quaternions, because
+		 * in case the user makes a change, we want to update the matrix and
+		 * local transformation values. However, some of our own code adjusts
+		 * these values as well, in that case we will temporarily set this flag
+		 * to ignore these events.
+		 * @private
+		 */
+		this._ignoreWorldChanges = false;
 
 		/** @private */
 		this.boundOnWorldPosChange = this.onWorldPosChange.bind(this);
@@ -443,9 +452,11 @@ export class Entity {
 		this.updateWorldMatrixIfDirty();
 		if (!this.worldPosRotScaleDirty) return;
 		const {pos, rot, scale} = this._worldMatrix.decompose();
+		this._ignoreWorldChanges = true;
 		this._worldPos.set(pos);
 		this._worldRot.set(rot);
 		this._worldScale.set(scale);
+		this._ignoreWorldChanges = false;
 		this.worldPosRotScaleDirty = false;
 	}
 
@@ -454,6 +465,7 @@ export class Entity {
 	 * @param {number} changedComponents
 	 */
 	onWorldPosChange(changedComponents) {
+		if (this._ignoreWorldChanges) return;
 		let pos;
 
 		if (changedComponents == 0x111) {
@@ -489,6 +501,7 @@ export class Entity {
 	 * @param {number} changedComponents
 	 */
 	onWorldRotChange(changedComponents) {
+		if (this._ignoreWorldChanges) return;
 		let rot;
 
 		if (changedComponents == 0x1111) {
@@ -527,6 +540,7 @@ export class Entity {
 	 * @param {number} changedComponents
 	 */
 	onWorldScaleChange(changedComponents) {
+		if (this._ignoreWorldChanges) return;
 		let scale;
 
 		if (changedComponents == 0x111) {

--- a/test/unit/src/core/Entity/transformations.test.js
+++ b/test/unit/src/core/Entity/transformations.test.js
@@ -1,5 +1,5 @@
 import {assertEquals} from "std/testing/asserts.ts";
-import {stub} from "std/testing/mock.ts";
+import {assertSpyCalls, spy, stub} from "std/testing/mock.ts";
 import {Entity, Mat4, Quat, Vec3} from "../../../../../src/mod.js";
 import {assertMatAlmostEquals, assertVecAlmostEquals} from "../../../shared/asserts.js";
 
@@ -514,3 +514,27 @@ Deno.test({
 		}
 	},
 });
+
+Deno.test({
+	name: "Issue #203: Changing parent transformation shouldn't adjust local transformation from children",
+	fn() {
+		const parent = new Entity("parent");
+		const child = new Entity("child");
+		parent.add(child);
+		const originalLocalRot = new Quat();
+		originalLocalRot.setFromAxisAngle(Vec3.up, 0.5);
+		child.rot.set(originalLocalRot);
+		child.scale.set(0.1, 0.2, 0.3);
+
+		const rotChangeSpy = spy();
+		child.rot.onChange(rotChangeSpy);
+
+		parent.rot.setFromAxisAngle(Vec3.up, 0.5);
+		parent.worldRot;
+		child.worldRot;
+
+		assertSpyCalls(rotChangeSpy, 0);
+		assertVecAlmostEquals(child.rot.toAxisAngle(), originalLocalRot.toAxisAngle());
+	},
+});
+

--- a/test/unit/src/core/Entity/transformations.test.js
+++ b/test/unit/src/core/Entity/transformations.test.js
@@ -530,7 +530,9 @@ Deno.test({
 		child.rot.onChange(rotChangeSpy);
 
 		parent.rot.setFromAxisAngle(Vec3.up, 0.5);
+		/* eslint-disable-next-line no-unused-expressions */
 		parent.worldRot;
+		/* eslint-disable-next-line no-unused-expressions */
 		child.worldRot;
 
 		assertSpyCalls(rotChangeSpy, 0);


### PR DESCRIPTION
Fixes #203