### PR TITLE
chore: Downgrade actions/github-script

### DIFF
--- a/.github/workflows/deploy-canary.yml
+++ b/.github/workflows/deploy-canary.yml
@@ -15,7 +15,7 @@ jobs:
       url: https://canary.renda.studio/
     steps:
       - name: Download build artifact
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         with:
           script: |
             let artifacts = await github.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
 
       - name: Download build artifact
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         with:
           script: |
             let artifacts = await github.actions.listWorkflowRunArtifacts({
@@ -46,7 +46,7 @@ jobs:
 
       - name: Get PR number
         id: get-pr-number
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -66,7 +66,7 @@ jobs:
       # directly to the deployed page.
       - name: Create deployment for status
         id: create-deployment
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         env:
           BUILD_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           PR_ID: ${{ steps.get-pr-number.outputs.result }}
@@ -89,7 +89,7 @@ jobs:
 
       - name: Update deployment status with in progress
         if: ${{ failure() }}
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         env:
           DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.result }}
         with:
@@ -111,7 +111,7 @@ jobs:
           curl -X POST --fail -H "Authorization: DeployToken $PR_DEPLOY_TOKEN" -H "Content-Type: application/x-tar" --data-binary @build_files.tar "https://deploy.renda.studio/pr?id=$PR_ID"
 
       - name: Update deployment status success
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         env:
           DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.result }}
           PR_ID: ${{ steps.get-pr-number.outputs.result }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Update deployment status failure
         if: ${{ failure() }}
-        uses: actions/github-script@d556feaca394842dc55e4734bf3bb9f685482fa0
+        uses: actions/github-script@f05a81df23035049204b043b50c3322045ce7eb3
         env:
           DEPLOYMENT_ID: ${{ steps.create-deployment.outputs.result }}
         with:


### PR DESCRIPTION
Because of https://github.com/actions/github-script/issues/286, deployments were failing. We'll downgrade for now until a fix is available.