### PR TITLE
feat: Generate services script for applications without building

### DIFF
--- a/editor/src/assets/ProjectAssetTypeManager.js
+++ b/editor/src/assets/ProjectAssetTypeManager.js
@@ -49,6 +49,12 @@ export class ProjectAssetTypeManager {
 		return this.registeredAssetTypes.get(type) ?? null;
 	}
 
+	*getAssetTypeIds() {
+		for (const id of this.registeredAssetTypes.keys()) {
+			yield id;
+		}
+	}
+
 	/**
 	 * @param {import("../../../src/util/mod.js").UuidString} uuid
 	 */

--- a/editor/src/assets/projectAssetType/ProjectAssetTypeEntity.js
+++ b/editor/src/assets/projectAssetType/ProjectAssetTypeEntity.js
@@ -228,6 +228,12 @@ export class ProjectAssetTypeEntity extends ProjectAssetType {
 				}
 			}
 
+			if (ctx.includeAll) {
+				for (const component of ctx.editor.componentTypeManager.getAllComponents()) {
+					usedComponentTypes.add(component);
+				}
+			}
+
 			let extraText = `const componentTypeManager = new ComponentTypeManager();
 entityLoader.setComponentTypeManager(componentTypeManager);`;
 

--- a/editor/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/editor/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -192,7 +192,7 @@ export class ContentWindowBuildView extends ContentWindow {
 				throw new Error("Assertion failed, selected entry point doesn't exist or has been removed.");
 			}
 			const clientId = await this.editorInstance.serviceWorkerManager.getClientId();
-			const newSrc = `projectbuilds/${clientId}/${path.join("/")}`;
+			const newSrc = `sw/clients/${clientId}/projectFiles/${path.join("/")}`;
 			if (this.iframeEl.src != newSrc || allowReload) {
 				this.iframeEl.src = newSrc;
 			}

--- a/editor/sw.js
+++ b/editor/sw.js
@@ -1,57 +1,111 @@
+import {TypedMessenger} from "../src/util/TypedMessenger.js";
+
+const castSelf = /** @type {unknown} */ (self);
+const swSelf = /** @type {ServiceWorkerGlobalScope} */ (castSelf);
+
 self.addEventListener("install", e => {
 });
 self.addEventListener("activate", e => {
 });
 
-async function asyncMessage(client, message) {
-	const channel = new MessageChannel();
-	client.postMessage(message, [channel.port2]);
-	return await new Promise(resolve => {
-		channel.port1.addEventListener("message", e => {
-			channel.port1.close();
-			resolve(e.data);
-		});
-		channel.port1.start();
+/**
+ * @param {Client} client
+ */
+function getMessageHandlers(client) {
+	return {
+		requestClientId() {
+			return client.id;
+		},
+	};
+}
+/** @typedef {ReturnType<getMessageHandlers>} ServiceWorkerMessageHandlers */
+
+/** @typedef {TypedMessenger<import("./src/misc/ServiceWorkerManager.js").ServiceWorkerManagerMessageHandlers, ServiceWorkerMessageHandlers>} TypedMessengerWithTypes */
+
+/** @type {Map<string, TypedMessengerWithTypes>} */
+const typedMessengers = new Map();
+/**
+ * @param {Client} client
+ */
+function getTypedMessenger(client) {
+	const existing = typedMessengers.get(client.id);
+	if (existing) return existing;
+
+	/** @type {TypedMessengerWithTypes} */
+	const messenger = new TypedMessenger();
+	messenger.setSendHandler(data => {
+		client.postMessage(data.sendData, data.transfer);
 	});
+	messenger.setResponseHandlers(getMessageHandlers(client));
+	typedMessengers.set(client.id, messenger);
+	return messenger;
 }
 
-async function getProjectFileResponse(e, pathname) {
-	pathname = pathname.slice(14); // remove /projectbuilds/ from url string
-	const slashIndex = pathname.indexOf("/");
-	const clientId = pathname.slice(0, slashIndex);
-	const filePath = pathname.slice(slashIndex + 1);
-	const client = await clients.get(clientId);
-	if (!client) {
-		return new Response("Editor client not found", {status: 500});
-	}
-	const file = await asyncMessage(client, {
-		type: "getProjectFile",
-		filePath,
-	});
-	const headers = {};
-	headers["Content-Length"] = file.size;
-	return new Response(file, {
-		headers,
-	});
-}
-
-self.addEventListener("fetch", e => {
-	const url = new URL(e.request.url);
-	const scopeUrl = new URL(self.registration.scope);
-	if (url.pathname.startsWith(scopeUrl.pathname)) {
-		const pathname = url.pathname.slice(scopeUrl.pathname.length);
-		if (pathname.startsWith("projectbuilds/")) {
-			e.respondWith(getProjectFileResponse(e, pathname));
+// Remove old typed messengers
+setInterval(async () => {
+	for (const id of typedMessengers.keys()) {
+		const client = await swSelf.clients.get(id);
+		if (!client) {
+			typedMessengers.delete(id);
 		}
+	}
+}, 120_000);
+
+swSelf.addEventListener("message", e => {
+	if (e.source instanceof Client) {
+		const messenger = getTypedMessenger(e.source);
+		messenger.handleReceivedMessage(e.data);
 	}
 });
 
-self.addEventListener("message", e => {
-	if (e.data.type == "requestClientId") {
-		const clientId = e.source.id;
-		if (e.ports.length > 0) {
-			for (const port of e.ports) {
-				port.postMessage(clientId);
+/**
+ * @param {string} clientId
+ * @param {string} pathname
+ */
+async function getClientResponse(clientId, pathname) {
+	const client = await swSelf.clients.get(clientId);
+	if (!client) {
+		return new Response("Editor client not found", {status: 404});
+	}
+	const messenger = getTypedMessenger(client);
+	const projectFilesPrefix = "projectFiles/";
+	if (pathname.startsWith(projectFilesPrefix)) {
+		const filePath = pathname.slice(projectFilesPrefix.length);
+		const file = await messenger.send("getProjectFile", filePath);
+		/** @type {HeadersInit} */
+		const headers = {};
+		headers["Content-Length"] = String(file.size);
+		return new Response(file, {
+			headers,
+		});
+	} else if (pathname == "services.js") {
+		const servicesScript = await messenger.send("getGeneratedServices");
+		return new Response(servicesScript, {
+			headers: {
+				"content-type": "application/javascript",
+			},
+		});
+	}
+	return new Response("Not found", {
+		status: 404,
+	});
+}
+
+swSelf.addEventListener("fetch", e => {
+	const url = new URL(e.request.url);
+	const scopeUrl = new URL(swSelf.registration.scope);
+	if (url.pathname.startsWith(scopeUrl.pathname)) {
+		const pathname = url.pathname.slice(scopeUrl.pathname.length);
+		const swPrefix = "sw/";
+		if (pathname.startsWith(swPrefix)) {
+			const swPathname = pathname.slice(swPrefix.length);
+			const clientsPrefix = "clients/";
+			if (swPathname.startsWith(clientsPrefix)) {
+				const clientsPathname = swPathname.slice(clientsPrefix.length);
+				const slashIndex = clientsPathname.indexOf("/");
+				const clientId = clientsPathname.slice(0, slashIndex);
+				const clientPath = clientsPathname.slice(slashIndex + 1);
+				e.respondWith(getClientResponse(clientId, clientPath));
 			}
 		}
 	}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,7 +1,7 @@
 {
 	"extends": "./.denoTypes/tsconfig.json",
 	"compilerOptions": {
-		"lib": ["dom", "dom.iterable", "esnext"],
+		"lib": ["dom", "dom.iterable", "esnext", "WebWorker"],
 		"target": "esnext",
 		"checkJs": true,
 		"module": "esnext",
@@ -14,6 +14,7 @@
 		"src/**/*.ts",
 		"editor/src/**/*.js",
 		"editor/src/**/*.ts",
+		"editor/sw.js",
 		"editor/devSocket/src/**/*.js",
 		"editor/devSocket/src/**/*.ts",
 		"editor/editorDiscoveryServer/src/**/*.js",

--- a/test/unit/editor/src/assets/ProjectAssetTypeManager.test.js
+++ b/test/unit/editor/src/assets/ProjectAssetTypeManager.test.js
@@ -125,6 +125,17 @@ Deno.test({
 });
 
 Deno.test({
+	name: "getAssetTypeIds()",
+	fn() {
+		const manager = new ProjectAssetTypeManager();
+		manager.registerAssetType(ExtendedProjectAssetType);
+
+		const result = Array.from(manager.getAssetTypeIds());
+		assertEquals(result, [BASIC_ASSET_TYPE]);
+	},
+});
+
+Deno.test({
 	name: "getAssetTypeByUuid()",
 	fn() {
 		const manager = new ProjectAssetTypeManager();


### PR DESCRIPTION
- A lot of messaging logic with the service worker has been refactored to use TypedMessenger.
- Some of the dynamic url paths have been changed.
- A new url has been added for fetching a generated services script.
- An option has been added to the generate services task to include all code regardless of the entry points and used assets.
- Added some extra jsdoc documentation to TypedMessenger.

Fixes #166