### PR TITLE
Make internal discovery work in production builds and remove facade chunks.

### DIFF
--- a/editor/scripts/build.js
+++ b/editor/scripts/build.js
@@ -148,12 +148,12 @@ const {output} = await bundle.write({
 });
 
 const editorEntryPointPath = path.resolve(EDITOR_ENTRY_POINT_PATH);
-const internalDiscoveryEntryPointPath = path.resolve(INTERNAL_DISCOVERY_ENTRY_POINT_PATH)
+const internalDiscoveryEntryPointPath = path.resolve(INTERNAL_DISCOVERY_ENTRY_POINT_PATH);
 let bundleEntryPoint;
 let internalDiscoveryEntryPoint;
 for (const chunkOrAsset of output) {
 	if (chunkOrAsset.type != "chunk") {
-		throw new Error("Assertion failed, unexpected type: "+ chunkOrAsset.type);
+		throw new Error("Assertion failed, unexpected type: " + chunkOrAsset.type);
 	}
 	if (chunkOrAsset.facadeModuleId == editorEntryPointPath) {
 		bundleEntryPoint = chunkOrAsset.fileName;

--- a/editor/src/network/editorConnections/EditorConnectionsManager.js
+++ b/editor/src/network/editorConnections/EditorConnectionsManager.js
@@ -61,7 +61,9 @@ export class EditorConnectionsManager {
 		/** @type {Set<function(ActiveEditorDataList) : void>} */
 		this.onActiveConnectionsChangedCbs = new Set();
 
-		this.internalDiscovery = new InternalDiscoveryManager();
+		this.internalDiscovery = new InternalDiscoveryManager({
+			fallbackDiscoveryUrl: new URL("internalDiscovery.html", window.location.href).href,
+		});
 		this.internalDiscovery.onConnectionCreated((otherClientId, messagePort) => {
 			let connection = this.activeConnections.get(otherClientId);
 			if (!connection) {

--- a/editor/src/network/editorConnections/internalDiscovery/internalDiscoveryMain.js
+++ b/editor/src/network/editorConnections/internalDiscovery/internalDiscoveryMain.js
@@ -9,7 +9,7 @@ import {TypedMessenger} from "../../../../../src/util/TypedMessenger.js";
  * @param {Object} params
  * @param {TypedMessenger<any, any>} params.workerTypedMessenger
  * @param {TypedMessenger<any, any>} params.parentWindowTypedMessenger
- * @param {() => void} params.destructorFunction
+ * @param {() => Promise<void>} params.destructorFunction
  */
 function getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destructorFunction}) {
 	return {
@@ -21,8 +21,8 @@ function getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destruct
 			postWorkerMessage(data, transfer) {
 				workerTypedMessenger.sendWithTransfer("parentWindowToWorkerMessage", transfer, data);
 			},
-			destructor() {
-				destructorFunction();
+			async destructor() {
+				await destructorFunction();
 			},
 		},
 		workerToIframeHandlers: {
@@ -44,10 +44,10 @@ function getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destruct
  */
 export function initializeIframe(window) {
 	let destructed = false;
-	function destructor() {
+	async function destructor() {
 		if (destructed) return;
 		destructed = true;
-		workerTypedMessenger.send("unregisterClient");
+		await workerTypedMessenger.send("unregisterClient");
 		worker.port.close();
 	}
 

--- a/editor/src/network/editorConnections/internalDiscovery/internalDiscoveryWorkerMain.js
+++ b/editor/src/network/editorConnections/internalDiscovery/internalDiscoveryWorkerMain.js
@@ -25,10 +25,13 @@ function sendAllClientAddedMessages(activeConnections, createdConnection) {
  * @param {Map<import("../../../../../src/mod.js").UuidString, InternalDiscoveryWorkerConnection>} activeConnections
  * @param {import("../../../../../src/util/mod.js").UuidString} clientId
  */
-function sendAllClientRemoved(activeConnections, clientId) {
+async function sendAllClientRemoved(activeConnections, clientId) {
+	const promises = [];
 	for (const connection of activeConnections.values()) {
-		connection.parentMessenger.send("availableClientRemoved", clientId);
+		const promise = connection.parentMessenger.send("availableClientRemoved", clientId);
+		promises.push(promise);
 	}
+	await Promise.all(promises);
 }
 
 /**
@@ -60,10 +63,10 @@ function getResponseHandlers(port, iframeMessenger, parentWindowMessenger, activ
 			parentWindowToWorkerMessage(data) {
 				parentWindowMessenger.handleReceivedMessage(data);
 			},
-			unregisterClient() {
+			async unregisterClient() {
 				if (!createdConnection) return;
 				activeConnections.delete(createdConnection.id);
-				sendAllClientRemoved(activeConnections, createdConnection.id);
+				await sendAllClientRemoved(activeConnections, createdConnection.id);
 				createdConnection = null;
 			},
 		},

--- a/src/Inspector/InspectorManager.js
+++ b/src/Inspector/InspectorManager.js
@@ -3,13 +3,20 @@ import {InspectorConnection} from "./InspectorConnection.js";
 import {InternalDiscoveryManager} from "./InternalDiscoveryManager.js";
 
 export class InspectorManager {
-	constructor() {
+	/**
+	 * @param {Object} options
+	 * @param {string} [options.fallbackDiscoveryUrl] If you wish to use the inspector on pages that are not hosted by
+	 * an editor, you should provide a fallback url for the discovery iframe of the editor you wish to connect with.
+	 */
+	constructor({
+		fallbackDiscoveryUrl = "",
+	} = {}) {
 		if (!ENABLE_INSPECTOR_SUPPORT) return;
 
 		/** @type {Map<import("../../editor/src/../../src/util/util.js").UuidString, InspectorConnection>} */
 		this.inspectorConnections = new Map();
 
-		this.internalDiscoveryManager = new InternalDiscoveryManager();
+		this.internalDiscoveryManager = new InternalDiscoveryManager({fallbackDiscoveryUrl});
 		this.internalDiscoveryManager.registerClient("inspector");
 		this.internalDiscoveryManager.onConnectionCreated((otherClientId, port) => {
 			const inspectorConnection = new InspectorConnection(otherClientId, port);

--- a/src/util/TypedMessenger.js
+++ b/src/util/TypedMessenger.js
@@ -91,7 +91,7 @@
  * @template {TypedMessengerSignatures} TReq
  * @template {TypedMessengerSignatures} TRes
  * @template {boolean} TRequireHandlerReturnObjects
- * @typedef {(data: TypedMessengerMessage<TReq, TRes, TRequireHandlerReturnObjects>) => void} TypedMessengerSendHandler
+ * @typedef {(data: TypedMessengerMessage<TReq, TRes, TRequireHandlerReturnObjects>) => void | Promise<void>} TypedMessengerSendHandler
  */
 
 /**
@@ -293,7 +293,7 @@ export class TypedMessenger {
 				returnValue = castReturn.returnValue;
 			}
 
-			this.sendHandler(/** @type {TypedMessengerResponseMessageHelper<TRes, typeof data.type, TRequireHandlerReturnObjects>} */ ({
+			await this.sendHandler(/** @type {TypedMessengerResponseMessageHelper<TRes, typeof data.type, TRequireHandlerReturnObjects>} */ ({
 				sendData: {
 					direction: "response",
 					id: data.id,
@@ -393,7 +393,7 @@ export class TypedMessenger {
 			});
 		});
 
-		this.sendHandler(/** @type {TypedMessengerRequestMessageHelper<TReq, T>} */ ({
+		await this.sendHandler(/** @type {TypedMessengerRequestMessageHelper<TReq, T>} */ ({
 			sendData: {
 				direction: "request",
 				id: requestId,


### PR DESCRIPTION
- updated the build file to include a hash in the main entry points of scripts
- make InternalDiscoveryManager communicate with parent window in order to get the discovery iframe url

Fixes #268
Fixes #300