### PR TITLE
fix: Don't show focus ring around treeviews when navigating using the arrow keys

### DIFF
--- a/studio/src/ui/treeView.css
+++ b/studio/src/ui/treeView.css
@@ -89,6 +89,9 @@
 .treeViewRow.hidden{
 	display: none;
 }
+.treeViewRow:focus-visible {
+	outline: none;
+}
 
 .treeViewArrow.hidden{
 	display: none;


### PR DESCRIPTION
Fixes #342