### PR TITLE
Fix: Light color doesn't initialize to [1,1,1]

### DIFF
--- a/src/components/builtIn/LightComponent.js
+++ b/src/components/builtIn/LightComponent.js
@@ -27,7 +27,18 @@ export class LightComponent extends Component {
 			},
 			color: {
 				type: "vec3",
+				guiOpts: {
+					defaultValue: new Vec3(1, 1, 1),
+					min: 0,
+					max: 1,
+				},
 			},
+			intensity: {
+				type: "number",
+				guiOpts: {
+					defaultValue: 1.0,
+				}
+			}
 		});
 	}
 
@@ -39,10 +50,12 @@ export class LightComponent extends Component {
 			structure: {
 				type: lightTypes,
 				color: [StorageType.FLOAT64],
+				intensity: StorageType.FLOAT64,
 			},
 			nameIds: {
 				type: 1,
 				color: 2,
+				intensity: 3,
 			},
 		};
 	}
@@ -56,6 +69,7 @@ export class LightComponent extends Component {
 
 		this.type = lightTypes[0];
 		this.color = new Vec3(1, 1, 1);
+		this.intensity = 1.0;
 
 		this.initValues(propertyValues, ...args);
 	}

--- a/src/components/builtIn/LightComponent.js
+++ b/src/components/builtIn/LightComponent.js
@@ -50,7 +50,7 @@ export class LightComponent extends Component {
 			structure: {
 				type: lightTypes,
 				color: [StorageType.FLOAT64],
-				intensity: StorageType.FLOAT64,
+				intensity: StorageType.FLOAT32,
 			},
 			nameIds: {
 				type: 1,

--- a/src/rendering/renderers/webGpu/WebGpuRenderer.js
+++ b/src/rendering/renderers/webGpu/WebGpuRenderer.js
@@ -313,7 +313,8 @@ export class WebGpuRenderer extends Renderer {
 			if (!light.entity) continue;
 			this.lightsBuffer.appendData(light.entity.pos);
 			this.lightsBuffer.skipBytes(4);
-			this.lightsBuffer.appendData(light.color);
+			// FIXME: a bit hacky; using color.multiplyScalar(intensity) doesn't work since the light.color vector will reclamp itself between 0 and 1.
+			this.lightsBuffer.appendData(new Vec3(light.color.x * light.intensity, light.color.y * light.intensity, light.color.z * light.intensity))
 			this.lightsBuffer.skipBytes(4);
 		}
 		this.lightsBuffer.writeAllChunksToGpu();

--- a/test/unit/src/components/builtIn/LightComponent.test.js
+++ b/test/unit/src/components/builtIn/LightComponent.test.js
@@ -1,6 +1,5 @@
-import {assertEquals, assertNotEquals} from "std/testing/asserts.ts";
-import {LightComponent, Entity, Vec2, Vec3} from "../../../../../src/mod.js";
-import {assertAlmostEquals, assertVecAlmostEquals} from "../../../shared/asserts.js";
+import {assertEquals} from "std/testing/asserts.ts";
+import {LightComponent, Vec3} from "../../../../../src/mod.js";
 
 Deno.test({
   name: "Light initializes with defaults",

--- a/test/unit/src/components/builtIn/LightComponent.test.js
+++ b/test/unit/src/components/builtIn/LightComponent.test.js
@@ -1,0 +1,38 @@
+import {assertEquals, assertNotEquals} from "std/testing/asserts.ts";
+import {LightComponent, Entity, Vec2, Vec3} from "../../../../../src/mod.js";
+import {assertAlmostEquals, assertVecAlmostEquals} from "../../../shared/asserts.js";
+
+Deno.test({
+  name: "Light initializes with defaults",
+  fn: () => {
+    const light = new LightComponent();
+    assertEquals(light.color.toArray(), [1, 1, 1]);
+    assertEquals(light.intensity, 1.0);
+    assertEquals(light.type, "point");
+  }
+});
+
+Deno.test({
+  name: "Light initializes with non-default options",
+  fn: () => {
+    const light = new LightComponent({
+      color: new Vec3(0.3, 0.5, 0.6),
+      type: "directional"
+    });
+    assertEquals(light.color.toArray(), [0.3, 0.5, 0.6]);
+    assertEquals(light.intensity, 1.0);
+    assertEquals(light.type, "directional");
+  }
+})
+
+Deno.test({
+  name: "set color clamps values between 0 and 1",
+  fn: () => {
+    const light = new LightComponent();
+    light.color = new Vec3(55, 35, 20);
+    assertEquals(light.color.toArray(), [1,1,1]);
+
+    light.color = new Vec3(-55, -35, -20);
+    assertEquals(light.color.toArray(), [0,0,0]);
+  }
+});

--- a/test/unit/src/components/builtIn/LightComponent.test.js
+++ b/test/unit/src/components/builtIn/LightComponent.test.js
@@ -24,15 +24,3 @@ Deno.test({
     assertEquals(light.type, "directional");
   }
 })
-
-Deno.test({
-  name: "set color clamps values between 0 and 1",
-  fn: () => {
-    const light = new LightComponent();
-    light.color = new Vec3(55, 35, 20);
-    assertEquals(light.color.toArray(), [1,1,1]);
-
-    light.color = new Vec3(-55, -35, -20);
-    assertEquals(light.color.toArray(), [0,0,0]);
-  }
-});


### PR DESCRIPTION
This PR fixes new lights not initializing to [1,1,1] and introduces an intensity value that allows light intensity to be determined independently of light color. Comes with a few added sanity tests for the LightComponent class.

In the future, it might be a good idea to consider abstracting the existing end-user color system from a series of 0-1 clamped sliders to a hex system or RGB (0-255) values.