### PR TITLE
Rewrite EntryPointManager as Popover subclass

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
 	},
 	"search.exclude": {
 		"deno.lock": true,
-	}
+	},
+	"files.eol": "\n",
 }

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -2,7 +2,7 @@ import {ContentWindow} from "../ContentWindow.js";
 import {Button} from "../../../ui/Button.js";
 import {getStudioInstance} from "../../../studioInstance.js";
 import {ButtonGroup} from "../../../ui/ButtonGroup.js";
-import {EntryPointManager, getSelectedEntryPoint} from "./EntryPointManager.js";
+import {EntryPointPopover, getSelectedEntryPoint} from "./EntryPointPopover.js";
 import {TypedMessenger} from "../../../../../src/util/TypedMessenger.js";
 import {ProjectAssetTypeJavascript} from "../../../assets/projectAssetType/ProjectAssetTypeJavascript.js";
 import {ProjectAssetTypeHtml} from "../../../assets/projectAssetType/ProjectAssetTypeHtml.js";
@@ -86,9 +86,8 @@ export class ContentWindowBuildView extends ContentWindow {
 				const projectSettings = studio.projectManager.projectSettings;
 				const assetManager = studio.projectManager.assetManager;
 				if (!projectSettings || !assetManager) return;
-				const popover = studio.popoverManager.createPopover();
-				// eslint-disable-next-line no-new
-				new EntryPointManager(popover, projectSettings, assetManager, this.persistentData);
+				const popover = studio.popoverManager.createPopover(EntryPointPopover);
+				popover.initialize(projectSettings, assetManager, this.persistentData);
 
 				popover.setNeedsCurtain(false);
 				popover.setPos(this.entryPointButton);

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -89,6 +89,7 @@ export class ContentWindowBuildView extends ContentWindow {
 				}
 
 				const popover = this.studioInstance.popoverManager.createPopover(EntryPointPopover);
+				popover.setNeedsCurtain(false);
 				popover.initialize(projectSettings, assetManager, this.persistentData);
 				popover.setPos(this.entryPointButton);
 			},

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -85,8 +85,9 @@ export class ContentWindowBuildView extends ContentWindow {
 				const projectSettings = this.studioInstance.projectManager.projectSettings;
 				const assetManager = this.studioInstance.projectManager.assetManager;
 
-				if (!projectSettings || !assetManager)
+				if (!projectSettings || !assetManager) {
 					throw new Error("Assertion failed, no project settings or asset manager.");
+				}
 
 				const popover = this.studioInstance.popoverManager.createPopover(EntryPointPopover);
 				popover.initialize(projectSettings, assetManager, this.persistentData);

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -1,6 +1,5 @@
 import {ContentWindow} from "../ContentWindow.js";
 import {Button} from "../../../ui/Button.js";
-import {getStudioInstance} from "../../../studioInstance.js";
 import {ButtonGroup} from "../../../ui/ButtonGroup.js";
 import {EntryPointPopover, getSelectedEntryPoint} from "./EntryPointPopover.js";
 import {TypedMessenger} from "../../../../../src/util/TypedMessenger.js";
@@ -114,7 +113,7 @@ export class ContentWindowBuildView extends ContentWindow {
 		this.updateIframeVisibility();
 		this.updateFrameSrc();
 		if (isRunning) {
-			getStudioInstance().projectManager.markCurrentProjectAsWorthSaving();
+			this.studioInstance.projectManager.markCurrentProjectAsWorthSaving();
 		}
 	}
 
@@ -127,7 +126,7 @@ export class ContentWindowBuildView extends ContentWindow {
 
 	async updateFrameSrc(allowReload = false) {
 		if (this.isRunning) {
-			const projectManager = getStudioInstance().projectManager;
+			const projectManager = this.studioInstance.projectManager;
 			const assetManager = projectManager.assetManager;
 			const projectSettings = projectManager.projectSettings;
 			if (!assetManager) {

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -82,14 +82,14 @@ export class ContentWindowBuildView extends ContentWindow {
 			hasDownArrow: true,
 			colorizerFilterManager,
 			onClick: () => {
-				const studio = getStudioInstance();
-				const projectSettings = studio.projectManager.projectSettings;
-				const assetManager = studio.projectManager.assetManager;
-				if (!projectSettings || !assetManager) return;
-				const popover = studio.popoverManager.createPopover(EntryPointPopover);
-				popover.initialize(projectSettings, assetManager, this.persistentData);
+				const projectSettings = this.studioInstance.projectManager.projectSettings;
+				const assetManager = this.studioInstance.projectManager.assetManager;
 
-				popover.setNeedsCurtain(false);
+				if (!projectSettings || !assetManager)
+					throw new Error("Assertion failed, no project settings or asset manager.");
+
+				const popover = this.studioInstance.popoverManager.createPopover(EntryPointPopover);
+				popover.initialize(projectSettings, assetManager, this.persistentData);
 				popover.setPos(this.entryPointButton);
 			},
 		});

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -62,13 +62,11 @@ export class EntryPointPopover extends Popover {
 		super(...args);
 
 		this.#selectorContainer = document.createElement("div");
-		// TODO: double check "this" works
 		this.el.appendChild(this.#selectorContainer);
 
 		const addContainer = document.createElement("div");
 		addContainer.style.display = "flex";
 		addContainer.style.width = "150px";
-		// TODO: double check
 		this.el.appendChild(addContainer);
 
 		this.#droppableGui = DroppableGui.of({

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -3,7 +3,7 @@ import {ProjectAssetTypeJavascript} from "../../../assets/projectAssetType/Proje
 import {Button} from "../../../ui/Button.js";
 import {ButtonSelectorGui} from "../../../ui/ButtonSelectorGui.js";
 import {DroppableGui} from "../../../ui/DroppableGui.js";
-import { Popover } from "../../../ui/popoverMenus/Popover.js";
+import {Popover} from "../../../ui/popoverMenus/Popover.js";
 
 const ENTRY_POINTS_SETTING_KEY = "buildView.entryPoints";
 const SELECTED_ENTRY_POINT_KEY = "selectedEntryPoint";

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -84,9 +84,8 @@ export class EntryPointPopover extends Popover {
 				this.#onAddButtonClick();
 			},
 		});
+
 		addContainer.appendChild(addButton.el);
-
-
 	}
 
 	/**
@@ -95,8 +94,9 @@ export class EntryPointPopover extends Popover {
 	 * @param {import("../../ContentWindowPersistentData.js").ContentWindowPersistentData} persistentData
 	 */
 	initialize(projectSettingsManager, assetManager, persistentData) {
-		if(this.#projectSettings)
+		if (this.#projectSettings) {
 			throw new Error("Error initializing EntryPointPopover: already initialized.");
+		}
 
 		this.#projectSettings = projectSettingsManager;
 		this.#assetManager = assetManager;
@@ -106,8 +106,9 @@ export class EntryPointPopover extends Popover {
 	}
 
 	async #loadPreferences() {
-		if(!this.#projectSettings || !this.#assetManager || !this.#persistentData)
+		if (!this.#projectSettings || !this.#assetManager || !this.#persistentData) {
 			throw new Error("Error loading preferences for EntryPointPopover: not initialized.");
+		}
 
 		const items = await getEntryPointsSetting(this.#projectSettings);
 		let entryPoint = null;
@@ -124,8 +125,9 @@ export class EntryPointPopover extends Popover {
 	 * @param {import("../../../../../src/mod.js").UuidString?} selectedEntryPoint
 	 */
 	async #updateSelector(items, selectedEntryPoint) {
-		if(!this.#assetManager)
+		if (!this.#assetManager) {
 			throw new Error("Error updating selector for EntryPointPopover: not initialized.");
+		}
 
 		/**
 		 * @typedef ItemData
@@ -175,8 +177,9 @@ export class EntryPointPopover extends Popover {
 				if (!itemData) {
 					throw new Error("Assertion failed, item data doesn't exist");
 				}
-				if(!this.#persistentData)
+				if (!this.#persistentData) {
 					throw new Error("Error updating selector for EntryPointPopover: persistentData is not initialized.");
+				}
 				this.#persistentData.set(SELECTED_ENTRY_POINT_KEY, itemData.uuid);
 			});
 			this.#currentSelectorEl = selector.el;
@@ -185,8 +188,9 @@ export class EntryPointPopover extends Popover {
 	}
 
 	async #onAddButtonClick() {
-		if(!this.#projectSettings || !this.#persistentData)
+		if (!this.#projectSettings || !this.#persistentData) {
 			throw new Error("Error adding entry point: not initialized.");
+		}
 
 		const addValue = this.#droppableGui.value;
 		if (!addValue) return;

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.test.js
@@ -1,8 +1,8 @@
-import {getMockArgs} from "./shared.js";
-import {ContentWindowBuildView} from "../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js";
-import {runWithDom} from "../../../shared/runWithDom.js";
-import {GestureInProgressManager} from "../../../../../../studio/src/misc/GestureInProgressManager.js";
-import {TypedMessenger} from "../../../../../../src/util/TypedMessenger.js";
+import {getMockArgs} from "../shared.js";
+import {ContentWindowBuildView} from "../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js";
+import {runWithDom} from "../../../../shared/runWithDom.js";
+import {GestureInProgressManager} from "../../../../../../../studio/src/misc/GestureInProgressManager.js";
+import {TypedMessenger} from "../../../../../../../src/util/TypedMessenger.js";
 import {assertEquals} from "std/testing/asserts.ts";
 
 Deno.test({
@@ -19,7 +19,7 @@ Deno.test({
 				mockStudioInstance.gestureInProgressManager = new GestureInProgressManager();
 
 				/**
-				 * @type {TypedMessenger<import("../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers, {}>}
+				 * @type {TypedMessenger<import("../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers, {}>}
 				 */
 				const iframeWindowMessenger = new TypedMessenger();
 


### PR DESCRIPTION
Fixes #444

This PR refactors the `EntryPointManager` class to a subclass of `Popover`.

This PR also fixes a small issue where the curtain would not appear, leading to some potential UI issues, and moves one test case to a path that better mirrors the existing `studio/` file structure.

