### PR TITLE
test: Disable flaky embedded assets e2e test

### DIFF
--- a/test/e2e/studio/src/assets/embeddedAssets.test.js
+++ b/test/e2e/studio/src/assets/embeddedAssets.test.js
@@ -23,6 +23,7 @@ async function findMapTreeViewEntry(page, assetContentEl) {
 
 await runE2eTest({
 	name: "Creating a new material asset with embedded map and pipeline config",
+	ignore: true,
 	async fn() {
 		const {page} = await getPage();
 		await setupNewProject(page);


### PR DESCRIPTION
We'll disable this test for now until a fix for #520 is available.