### PR TITLE
test: Various improvements for running e2e tests locally

### DIFF
--- a/test/e2e/shared/browser.js
+++ b/test/e2e/shared/browser.js
@@ -48,6 +48,7 @@ let browser = null;
  */
 export async function launch({headless}) {
 	const executablePath = await installIfNotInstalled();
+	console.log(`Launching ${executablePath}`);
 	browser = await puppeteer.launch({
 		headless,
 		args: ["--enable-unsafe-webgpu"],

--- a/test/e2e/shared/browser.js
+++ b/test/e2e/shared/browser.js
@@ -10,7 +10,7 @@ export function setMainPageUrl(url) {
 }
 function getMainPageUrl() {
 	if (!mainPageUrl) {
-		throw new Error("Failed to get main page url, no test server address provided via args.");
+		throw new Error("Failed to get main page url, use `setMainPageUrl` first.");
 	}
 	return mainPageUrl;
 }
@@ -41,6 +41,10 @@ async function installIfNotInstalled() {
 
 /** @type {import("puppeteer").Browser?} */
 let browser = null;
+let browserStartedWithHeadless = false;
+
+/** @type {import("puppeteer").Page?} */
+let defaultPage = null;
 
 /**
  * @param {object} options
@@ -55,11 +59,17 @@ export async function launch({headless}) {
 		devtools: !headless,
 		executablePath,
 	});
+	browserStartedWithHeadless = headless;
+	const pages = await browser.pages();
+	defaultPage = pages[0];
 	return browser;
 }
 
 /** @type {Set<import("puppeteer").BrowserContext>} */
 const contexts = new Set();
+
+/** @type {Set<import("puppeteer").Page>} */
+const pages = new Set();
 
 /**
  * Creates a new incognito context and a page.
@@ -73,6 +83,8 @@ export async function getPage(url = getMainPageUrl() + "/studio/") {
 	const context = await browser.createIncognitoBrowserContext();
 	contexts.add(context);
 	const page = await context.newPage();
+	pages.add(page);
+	await updateDefaultPageVisibility();
 	page.on("console", async message => {
 		const jsonArgs = [];
 		for (const arg of message.args()) {
@@ -85,21 +97,56 @@ export async function getPage(url = getMainPageUrl() + "/studio/") {
 		context,
 		page,
 		async discard() {
+			pages.delete(page);
 			contexts.delete(context);
+			await updateDefaultPageVisibility();
 			await context.close();
 		},
 	};
 }
 
 /**
+ * The page from the default context is always empty and only sits in the way.
+ * But the Chrome process exits when the last page is closed, herefore we can't close it on startup.
+ * Instead we'll close it once at least one other page is opened.
+ * Then we open it again right before the last page is closed.
+ * That way the browser process never exits.
+ */
+async function updateDefaultPageVisibility() {
+	// If we're in headless mode, let's not do any of this.
+	// We don't want to make ci more flaky.
+	// Even though in headless mode the browser does not seem to exit when the last page is closed.
+	if (browserStartedWithHeadless) return;
+
+	if (!browser) {
+		throw new Error("Assertion failed, browser was not launched.");
+	}
+	const needsDefaultPage = pages.size === 0;
+	const hasDefaultPage = Boolean(defaultPage);
+	if (needsDefaultPage != hasDefaultPage) {
+		if (defaultPage) {
+			await defaultPage.close();
+			defaultPage = null;
+		} else {
+			const ctx = browser.defaultBrowserContext();
+			defaultPage = await ctx.newPage();
+		}
+	}
+}
+
+/**
  * Discards all created contexts. Called by the test runner at the end of a test.
  */
 export async function discardCurrentContexts() {
+	const contextsCopy = [...contexts];
+	contexts.clear();
+	pages.clear();
+	await updateDefaultPageVisibility();
+
 	const promises = [];
-	for (const context of contexts) {
+	for (const context of contextsCopy) {
 		promises.push(context.close());
 	}
-	contexts.clear();
 	await Promise.all(promises);
 }
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -12,9 +12,9 @@ You can optionally provide a path to only run a specific portion of the test sui
 The test script takes some optional parameters:
 
 - `-i`, `--inspect` to wait for a debugger to connect, this also automatically disables headless mode for e2e tests.
+- `-h`, `--headless` toggles the default headless behaviour. Headless mode is disabled by default unless `-i` or `--inspect` have been specified.
 - `-c`, `--coverage` generates a coverage file in `.lcov` format. This is useful if your IDE supports it.
 - `--html` generates a coverage file in `.html` format. `genhtml` needs to be installed for this to work. The generated html can be found at `.coverage/html`.
-- `--no-headless` to disable headless mode in e2e tests.
 
 ## Unit tests
 

--- a/test/readme.md
+++ b/test/readme.md
@@ -63,6 +63,23 @@ For example, calling `e2e.logTreeViewPath($0)` will tell you the path that would
 `getTreeViewItemElement()` function in `test/e2e/studio/shared/treeView.js`.
 In this case `$0` is [the most recently selected node](https://developer.chrome.com/blog/the-currently-selected-dom-node/).
 
+### Inspecting on Linux
+
+If you're running Linux and the e2e tests keep hanging at 'Launching [path to chrome]',
+This is likely because some executables are missing the required permissions.
+You can verify this by trying to execute the path to chrome manually.
+When doing so, you'll likely see something like:
+
+```
+spawn_subprocess.cc(221)] posix_spawn: Permission denied
+```
+
+You can solve this by adding execute permissions to `chrome_crashpad_handler`:
+
+```
+chmod +x chrome_crashpad_handler
+```
+
 ## Shared folders
 
 Some folders contain a `shared` folder, these contain code shared by more than one test file,

--- a/test/shared/testArgs.js
+++ b/test/shared/testArgs.js
@@ -1,7 +1,11 @@
-export const PUPPETEER_NO_HEADLESS_ARG = "--no-headless";
+import {parse} from "std/flags/mod.ts";
 
 export function parseArgs() {
-	const inspect = Deno.args.includes("--inspect") || Deno.args.includes("--inspect-brk") || Deno.args.includes("-i");
-	const headless = !Deno.args.includes(PUPPETEER_NO_HEADLESS_ARG) && !inspect;
+	const parsed = parse(Deno.args);
+	const inspect = parsed.inspect || parsed["inspect-brk"] || parsed.i;
+	let headless = !inspect;
+	if (parsed.headless || parsed.h) {
+		headless = !headless;
+	}
 	return {inspect, headless};
 }


### PR DESCRIPTION
- Adds `-h`/`--headless` and removes `--no-headless`. This flag toggles the default behaviour rather than just disabling headless mode. Allowing you to run in headless mode even though `--inspect` is used.
- Adds some documentation about permission issues on Linux
- Makes sure the page from the default context is hidden when headless is disabled. This page is always empty and only sits in the way.