### PR TITLE
feat: Don't resolve SingleInstancePromise.waitForFinishIfRunning when the queue is not empty

### DIFF
--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -97,7 +97,7 @@ export class SingleInstancePromise {
 	 */
 	async waitForFinish() {
 		if (this.once) {
-			throw new Error("waitForFinish() will stay pending forever when once has been set, use waitForFinishOnce() instead.");
+			throw new Error("waitForFinish() would stay pending forever when once has been set, use waitForFinishOnce() instead.");
 		}
 		/** @type {Promise<void>} */
 		const promise = new Promise(r => this._onFinishCbs.add(r));
@@ -118,8 +118,10 @@ export class SingleInstancePromise {
 	}
 
 	/**
-	 * Returns a promise that will resolve once the function is done running.
+	 * Returns a promise that will resolve once all calls to the function is done running.
 	 * Resolves immediately if the function is not running, either because it is done or if it has already run.
+	 * If a new call is made to `run` while the function was still running,
+	 * this promise will not resolve until that run is done as well.
 	 */
 	async waitForFinishIfRunning() {
 		while (this._isEmptyingQueue) {

--- a/src/util/SingleInstancePromise.js
+++ b/src/util/SingleInstancePromise.js
@@ -122,9 +122,10 @@ export class SingleInstancePromise {
 	 * Resolves immediately if the function is not running, either because it is done or if it has already run.
 	 */
 	async waitForFinishIfRunning() {
-		if (!this._isEmptyingQueue) return;
-		/** @type {Promise<void>} */
-		const promise = new Promise(r => this._onFinishCbs.add(r));
-		await promise;
+		while (this._isEmptyingQueue) {
+			/** @type {Promise<void>} */
+			const promise = new Promise(r => this._onFinishCbs.add(r));
+			await promise;
+		}
 	}
 }

--- a/test/unit/src/util/SingleInstancePromise.test.js
+++ b/test/unit/src/util/SingleInstancePromise.test.js
@@ -175,7 +175,7 @@ Deno.test({
 		const instance = new SingleInstancePromise(async () => {}, {once: true});
 		await assertRejects(async () => {
 			await instance.waitForFinish();
-		}, Error, "waitForFinish() will stay pending forever when once has been set, use waitForFinishOnce() instead.");
+		}, Error, "waitForFinish() would stay pending forever when once has been set, use waitForFinishOnce() instead.");
 	},
 });
 


### PR DESCRIPTION
Fixes #529

Previously `waitForFinishIfRunning` would resolve as soon as the first run was done. But more often than not when this function is used, you want it to resolve after *all* runs are done.

At the moment it seems like there are no cases where you'd want the old behaviour. If we ever need this again in the future we can either add a new method or add a parameter to this method.