### PR TITLE
fix: Don't change focus to outliner treeview unless the content window element has been clicked

### DIFF
--- a/studio/src/windowManagement/StudioWindow.js
+++ b/studio/src/windowManagement/StudioWindow.js
@@ -2,7 +2,7 @@ export class StudioWindow {
 	#focusWithin = false;
 	/** @type {Set<(hasFocus: boolean) => any>} */
 	#onFocusedChangeCbs = new Set();
-	/** @type {Set<() => any>} */
+	/** @type {Set<(e: MouseEvent) => any>} */
 	#onClickWithinCbs = new Set();
 
 	/**
@@ -17,8 +17,8 @@ export class StudioWindow {
 		this.windowManager = windowManager;
 		this.isRoot = false;
 
-		this.el.addEventListener("click", () => {
-			this.#onClickWithinCbs.forEach(cb => cb());
+		this.el.addEventListener("click", e => {
+			this.#onClickWithinCbs.forEach(cb => cb(e));
 		});
 		this.el.addEventListener("focusin", e => {
 			this.#updateFocusWithin(e.target);
@@ -69,7 +69,7 @@ export class StudioWindow {
 	}
 
 	/**
-	 * @param {() => void} cb
+	 * @param {(e: MouseEvent) => void} cb
 	 */
 	onClickWithin(cb) {
 		this.#onClickWithinCbs.add(cb);

--- a/studio/src/windowManagement/WindowManager.js
+++ b/studio/src/windowManagement/WindowManager.js
@@ -349,8 +349,9 @@ export class WindowManager {
 					this.addContentWindowToLastFocused(castWindow.activeTab);
 				}
 			});
-			castWindow.onClickWithin(() => {
-				this.addContentWindowToLastClicked(castWindow.activeTab);
+			castWindow.onClickWithin(e => {
+				const mayChangeFocus = (e.target == castWindow.activeTab.contentEl);
+				this.#addContentWindowToLastClicked(castWindow.activeTab, mayChangeFocus);
 			});
 			castWindow.onFocusedWithinChange(hasFocus => {
 				if (hasFocus) {
@@ -365,12 +366,17 @@ export class WindowManager {
 	}
 
 	/**
-	 * @private
 	 * @param {ContentWindow} contentWindow
+	 * @param {boolean} mayChangeFocus
 	 */
-	addContentWindowToLastClicked(contentWindow) {
+	#addContentWindowToLastClicked(contentWindow, mayChangeFocus) {
 		this.lastClickedContentWindow = contentWindow;
-		contentWindow.activate();
+		// We call activate regardless of whether we already called it before or not.
+		// This is because in the previous call `mayChangeFocus` may have been false
+		// and we want to notify the contentWindow if this is the case.
+		// In the future we could possibly keep track of this state and prevent multiple calls when the state hasn't changed.
+		// But since no content window has any issues with the current behaviour, we'll keep it like this for now.
+		contentWindow.activate(mayChangeFocus);
 		const castConstructor = /** @type {typeof ContentWindow} */ (contentWindow.constructor);
 		this.#lastClickedValueSetter?.setValue(castConstructor.contentWindowTypeId);
 	}

--- a/studio/src/windowManagement/contentWindows/ContentWindow.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindow.js
@@ -134,8 +134,11 @@ export class ContentWindow {
 	 * Gets called when the user clicks this content window so that it receives focus.
 	 * Normally you would use this to activate any selection groups related to the contentwindow.
 	 * This maybe called multiple times even though the window is already active.
+	 * @param {boolean} mayChangeFocus If this is false, an input element was clicked
+	 * and you should refrain from changing the focus to another element,
+	 * since that could move the focus away from the clicked element.
 	 */
-	activate() {}
+	activate(mayChangeFocus) {}
 
 	/**
 	 * @param {number} w

--- a/studio/src/windowManagement/contentWindows/ContentWindowOutliner.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowOutliner.js
@@ -239,9 +239,12 @@ export class ContentWindowOutliner extends ContentWindow {
 		this.selectionGroup.changeSelection(changeData);
 	}
 
-	/** @override */
-	activate() {
-		this.treeView.focusIfNotFocused();
+	/**
+	 * @override
+	 * @param {boolean} mayChangeFocus
+	 */
+	activate(mayChangeFocus) {
+		if (mayChangeFocus) this.treeView.focusIfNotFocused();
 		this.selectionGroup?.activate();
 	}
 


### PR DESCRIPTION
Fixes #359