### PR TITLE
refactor: Workspace update event improvements

### DIFF
--- a/studio/src/windowManagement/contentWindows/ContentWindow.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindow.js
@@ -104,9 +104,12 @@ export class ContentWindow {
 		this.parentStudioWindow = parentStudioWindow;
 	}
 
-	detachParentStudioWindow() {
+	/**
+	 * @param {import("../StudioWindow.js").WorkspaceChangeTrigger} trigger
+	 */
+	detachParentStudioWindow(trigger) {
 		if (!this.parentStudioWindow) return;
-		this.parentStudioWindow.contentWindowDetached(this);
+		this.parentStudioWindow.contentWindowDetached(this, trigger);
 		this.parentStudioWindow = null;
 	}
 


### PR DESCRIPTION
- Instead of windows registering callbacks on children, events now automatically propagate up to the root and only fire the event there.
- events contain a `trigger` property, indicating what caused the update.