### PR TITLE
fix: Make handleGuiValueChange use the correct scope in the default asset links window

### DIFF
--- a/studio/src/projectSelector/ProjectManager.js
+++ b/studio/src/projectSelector/ProjectManager.js
@@ -313,7 +313,6 @@ export class ProjectManager {
 
 	/**
 	 * If the asset manager doesn't exist, waits for it to load and returns it.
-	 * Throws an error if it still doesn't exist after loading.
 	 */
 	async getAssetManager() {
 		if (this.assetManager && this.assetManager.assetSettingsLoaded) return this.assetManager;

--- a/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.js
@@ -41,7 +41,6 @@ export class ContentWindowDefaultAssetLinks extends ContentWindow {
 		this.contentEl.appendChild(this.treeView.el);
 
 		this.isLoadingAssetLinks = true;
-		this.isParsingValueChange = false;
 		this.treeView.onChildValueChange(this.#handleGuiValueChange);
 
 		this.loadDefaultAssetLinks();
@@ -118,9 +117,8 @@ export class ContentWindowDefaultAssetLinks extends ContentWindow {
 	/**
 	 * @param {import("../../ui/propertiesTreeView/types.js").PropertiesTreeViewChangeEvent<any>} changeEvent
 	 */
-	#handleGuiValueChange(changeEvent) {
+	#handleGuiValueChange = (changeEvent) => {
 		if (changeEvent.trigger != "user") return;
-		this.isParsingValueChange = true;
 
 		/** @type {import("../../assets/AssetManager.js").SetDefaultBuiltInAssetLinkData[]} */
 		const builtInAssetLinks = [];
@@ -155,6 +153,5 @@ export class ContentWindowDefaultAssetLinks extends ContentWindow {
 			const defaultAssetEntry = valueItem.gui.treeView.getSerializableStructureEntry("defaultAsset");
 			defaultAssetEntry?.gui.setValue(userDefaultAssetLinkUuids[i]);
 		}
-		this.isParsingValueChange = false;
 	}
 }

--- a/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.js
@@ -117,7 +117,7 @@ export class ContentWindowDefaultAssetLinks extends ContentWindow {
 	/**
 	 * @param {import("../../ui/propertiesTreeView/types.js").PropertiesTreeViewChangeEvent<any>} changeEvent
 	 */
-	#handleGuiValueChange = (changeEvent) => {
+	#handleGuiValueChange = changeEvent => {
 		if (changeEvent.trigger != "user") return;
 
 		/** @type {import("../../assets/AssetManager.js").SetDefaultBuiltInAssetLinkData[]} */
@@ -153,5 +153,5 @@ export class ContentWindowDefaultAssetLinks extends ContentWindow {
 			const defaultAssetEntry = valueItem.gui.treeView.getSerializableStructureEntry("defaultAsset");
 			defaultAssetEntry?.gui.setValue(userDefaultAssetLinkUuids[i]);
 		}
-	}
+	};
 }

--- a/test/unit/studio/shared/createMockAssetManager.js
+++ b/test/unit/studio/shared/createMockAssetManager.js
@@ -1,0 +1,7 @@
+export function createMockAssetManager() {
+	const assetManager = /** @type {import("../../../../studio/src/assets/AssetManager.js").AssetManager} */ ({
+		getProjectAssetFromUuidSync(uuid) {},
+	});
+
+	return {assetManager};
+}

--- a/test/unit/studio/shared/runWithMockStudio.js
+++ b/test/unit/studio/shared/runWithMockStudio.js
@@ -1,0 +1,37 @@
+
+// I tried combining these two functions into one, but that doesn't work because
+// it will cause tests with non async functions to throw outside of the test.
+// That way Deno's test runner is not able to know which test the error originated from.
+
+import {injectMockStudioInstance} from "../../../../studio/src/studioInstance.js";
+
+/**
+ * Runs the function with an installed fake dom.
+ * Ensures global scope is cleaned up after running, even if errors are thrown.
+ * @param {import("../../../../studio/src/Studio.js").Studio} studioInstance
+ * @param {() => void | undefined} fn
+ */
+export function runWithMockStudio(studioInstance, fn) {
+	injectMockStudioInstance(studioInstance);
+
+	try {
+		fn();
+	} finally {
+		injectMockStudioInstance(null);
+	}
+}
+
+/**
+ * Same as {@linkcode runWithMockStudio} but async.
+ * @param {import("../../../../studio/src/Studio.js").Studio} studioInstance
+ * @param {() => (Promise<void>)} fn
+ */
+export async function runWithMockStudioAsync(studioInstance, fn) {
+	injectMockStudioInstance(studioInstance);
+
+	try {
+		await fn();
+	} finally {
+		injectMockStudioInstance(null);
+	}
+}

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.test.js
@@ -6,7 +6,6 @@ import {createMockAssetManager} from "../../../shared/createMockAssetManager.js"
 import {waitForMicrotasks} from "../../../../shared/waitForMicroTasks.js";
 import {assertEquals, assertInstanceOf} from "std/testing/asserts.ts";
 import {runWithMockStudioAsync} from "../../../shared/runWithMockStudio.js";
-import {assertTreeViewStructureEquals} from "../../../shared/treeViewUtil.js";
 import {PropertiesTreeViewEntry} from "../../../../../../studio/src/ui/propertiesTreeView/PropertiesTreeViewEntry.js";
 
 function basicSetup() {

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.test.js
@@ -1,0 +1,64 @@
+import {getMockArgs} from "./shared.js";
+import {ContentWindowDefaultAssetLinks} from "../../../../../../studio/src/windowManagement/contentWindows/ContentWindowDefaultAssetLinks.js";
+import {runWithDomAsync} from "../../../shared/runWithDom.js";
+import {stub} from "std/testing/mock.ts";
+import {createMockAssetManager} from "../../../shared/createMockAssetManager.js";
+import {waitForMicrotasks} from "../../../../shared/waitForMicroTasks.js";
+import {assertEquals, assertInstanceOf} from "std/testing/asserts.ts";
+import {runWithMockStudioAsync} from "../../../shared/runWithMockStudio.js";
+import {assertTreeViewStructureEquals} from "../../../shared/treeViewUtil.js";
+import {PropertiesTreeViewEntry} from "../../../../../../studio/src/ui/propertiesTreeView/PropertiesTreeViewEntry.js";
+
+function basicSetup() {
+	const {args, mockStudioInstance} = getMockArgs();
+	mockStudioInstance.projectManager = /** @type {import("../../../../../../studio/src/projectSelector/ProjectManager.js").ProjectManager} */ ({});
+	stub(mockStudioInstance.projectManager, "waitForAssetListsLoad");
+
+	const {assetManager} = createMockAssetManager();
+	assetManager.defaultAssetLinks = new Map();
+	stub(mockStudioInstance.projectManager, "getAssetManager", async () => assetManager);
+	stub(mockStudioInstance.projectManager, "assertAssetManagerExists", () => assetManager);
+	stub(assetManager, "getDefaultAssetLink");
+
+	/** @type {Set<import("../../../../../../studio/src/assets/autoRegisterBuiltInDefaultAssetLinks.js").BuiltInDefaultAssetLink>} */
+	const registeredAssetLinks = new Set();
+	mockStudioInstance.builtInDefaultAssetLinksManager = /** @type {import("../../../../../../studio/src/assets/BuiltInDefaultAssetLinksManager.js").BuiltInDefaultAssetLinksManager} */ ({
+		registeredAssetLinks,
+	});
+
+	return {
+		args,
+		registeredAssetLinks,
+		studio: mockStudioInstance,
+	};
+}
+
+Deno.test({
+	name: "Shows registered default asset links",
+	async fn() {
+		await runWithDomAsync(async () => {
+			const {args, registeredAssetLinks, studio} = basicSetup();
+
+			registeredAssetLinks.add({
+				defaultAssetUuid: "default asset uuid",
+				name: "default asset name",
+				originalAssetUuid: "original uuid",
+			});
+
+			await runWithMockStudioAsync(studio, async () => {
+				const contentWindow = new ContentWindowDefaultAssetLinks(...args);
+				await waitForMicrotasks();
+
+				assertEquals(contentWindow.builtInAssetLinksTreeView.children.length, 1);
+				const treeView = contentWindow.builtInAssetLinksTreeView.children[0];
+				assertInstanceOf(treeView, PropertiesTreeViewEntry);
+				const value = treeView.getValue();
+				assertEquals(value, {
+					// These values are null for now, because we haven't mocked the asset manager sufficiently.
+					defaultAsset: null,
+					originalAsset: null,
+				});
+			});
+		});
+	},
+});

--- a/test/unit/studio/src/windowManagement/contentWindows/shared.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/shared.js
@@ -17,6 +17,12 @@ export function getMockArgs() {
 		keyboardShortcutManager: {
 			onCommand(command, cb) {},
 			removeOnCommand(command, cb) {},
+			getCondition(name) {
+				const condition = /** @type {import("../../../../../../studio/src/keyboardShortcuts/ShortcutCondition.js").ShortcutCondition<any>} */ ({
+					requestValueSetter(priority) {},
+				});
+				return condition;
+			},
 		},
 	});
 


### PR DESCRIPTION
Fixes #642