### PR TITLE
fix: Use content window uuid for entityEditor.autosaveEntities events

### DIFF
--- a/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/EntitySavingManager.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/EntitySavingManager.js
@@ -22,6 +22,8 @@ export class EntitySavingManager {
 		this.studioInstance.preferencesManager.onChange("entityEditor.autosaveEntities", () => {
 			const autosave = this.#getAutosaveValue();
 			this.saveEntityButton.setVisibility(!autosave);
+		}, {
+			contentWindowUuid: entityEditor.uuid,
 		});
 
 		this.saveEntityAssetInstance = new SingleInstancePromise(async () => {


### PR DESCRIPTION
Fixes #673