### PR TITLE
feat: Fire entity change events when modifying entities

### DIFF
--- a/studio/src/assets/EntityAssetManager.js
+++ b/studio/src/assets/EntityAssetManager.js
@@ -193,7 +193,7 @@ export class EntityAssetManager {
 				};
 			}
 		}
-		throw new Error("Provided entity is not a child of an entity asset");
+		return null;
 	}
 
 	/**
@@ -206,11 +206,11 @@ export class EntityAssetManager {
 	 * @param {EntityChangeType} changeEventType
 	 */
 	updateEntity(entityInstance, changeEventType) {
-		const {uuid, root, indicesPath} = this.#findRootEntityAsset(entityInstance);
+		const rootData = this.#findRootEntityAsset(entityInstance);
+		if (!rootData) return;
+		const {uuid, root, indicesPath} = rootData;
 		const trackedData = this.#trackedEntities.get(uuid);
-		if (!trackedData) {
-			throw new Error("The provided entity asset is not tracked by this EntityAssetManager.");
-		}
+		if (!trackedData) return;
 
 		const sourceEntity = root.getEntityByIndicesPath(indicesPath);
 		if (!sourceEntity) throw new Error("Assertion failed: Source child entity was not found");
@@ -320,11 +320,11 @@ export class EntityAssetManager {
 	 * @param {Entity} entityInstance The entity for which the transformation was changed.
 	 */
 	updateEntityPosition(entityInstance) {
-		const {uuid, indicesPath, root} = this.#findRootEntityAsset(entityInstance);
+		const rootData = this.#findRootEntityAsset(entityInstance);
+		if (!rootData) return;
+		const {uuid, indicesPath, root} = rootData;
 		const trackedData = this.#trackedEntities.get(uuid);
-		if (!trackedData) {
-			throw new Error("The provided entity asset is not tracked by this EntityAssetManager.");
-		}
+		if (!trackedData) return;
 
 		for (const trackedEntity of trackedData.trackedInstances) {
 			if (trackedEntity == root) continue;

--- a/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/ContentWindowEntityEditor.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/ContentWindowEntityEditor.js
@@ -681,6 +681,7 @@ export class ContentWindowEntityEditor extends ContentWindow {
 				const newEntityMatrix = entity.worldMatrix;
 				newEntityMatrix.multiplyMatrix(pivotDragMatrix);
 				entity.worldMatrix = newEntityMatrix;
+				this.studioInstance.projectManager.assetManager?.entityAssetManager.updateEntityPosition(entity);
 				this.notifyEntityChanged(entity, "transform");
 			}
 		}

--- a/test/unit/studio/src/assets/EntityAssetManager.test.js
+++ b/test/unit/studio/src/assets/EntityAssetManager.test.js
@@ -1,4 +1,4 @@
-import {assertEquals, assertInstanceOf, assertNotStrictEquals, assertStrictEquals, assertThrows} from "std/testing/asserts.ts";
+import {assertEquals, assertInstanceOf, assertNotStrictEquals, assertStrictEquals} from "std/testing/asserts.ts";
 import {Entity, LightComponent} from "../../../../../src/mod.js";
 import {EntityAssetManager, EntityChangeType} from "../../../../../studio/src/assets/EntityAssetManager.js";
 import {waitForMicrotasks} from "../../../shared/waitForMicroTasks.js";
@@ -298,29 +298,25 @@ Deno.test({
 	async fn() {
 		const {manager} = basicSetup();
 
-		const entity = new Entity();
-		assertThrows(() => {
-			manager.updateEntity(entity, EntityChangeType.Create);
-		}, Error, "Provided entity is not a child of an entity asset");
-		assertThrows(() => {
-			manager.updateEntityPosition(entity);
-		}, Error, "Provided entity is not a child of an entity asset");
+		const entity = new Entity("root");
+		const child = entity.add(new Entity("child"));
+		manager.updateEntity(entity, EntityChangeType.Create);
+		manager.updateEntityPosition(entity);
+		assertStrictEquals(entity.children[0], child);
 	},
 });
 
 Deno.test({
-	name: "Trying to change an entity that is not being tracked throws",
+	name: "Trying to change an entity that is not being tracked does nothing",
 	async fn() {
 		const {manager} = basicSetup();
 
-		const entity = new Entity();
+		const entity = new Entity("root");
+		const child = entity.add(new Entity("child"));
 		manager.setLinkedAssetUuid(entity, "non existent uuid");
-		assertThrows(() => {
-			manager.updateEntity(entity, EntityChangeType.Create);
-		}, Error, "The provided entity asset is not tracked by this EntityAssetManager");
-		assertThrows(() => {
-			manager.updateEntityPosition(entity);
-		}, Error, "The provided entity asset is not tracked by this EntityAssetManager");
+		manager.updateEntity(entity, EntityChangeType.Create);
+		manager.updateEntityPosition(entity);
+		assertStrictEquals(entity.children[0], child);
 	},
 });
 


### PR DESCRIPTION
This doesn't cover all cases, but should be a good starting point:
 - Changing entity transformation when dragging using gizmos
 - Creating new child entities in the outliner
 - Renaming entities in the outliner
 - Deleting entities from the outliner