### PR TITLE
feat: Improved build view entry point system

### DIFF
--- a/studio/builtInAssets/assetSettings.json
+++ b/studio/builtInAssets/assetSettings.json
@@ -18,6 +18,9 @@
 		"36996838-4f7e-4be3-9c18-49c4a9db00be": {
 			"path": ["DefaultAssets", "Default Vertex State.json"]
 		},
+		"5a328430-e3bc-4eda-afab-789f00439f81": {
+			"path": ["buildSupport", "basicEntryPoint.js"]
+		},
 		"264a38b9-4e43-4261-b57d-28a778a12dd9": {
 			"path": ["buildSupport", "basicIndex.html"]
 		},

--- a/studio/builtInAssets/buildSupport/basicEntryPoint.js
+++ b/studio/builtInAssets/buildSupport/basicEntryPoint.js
@@ -1,0 +1,1 @@
+console.log("hello");

--- a/studio/src/assets/AssetManager.js
+++ b/studio/src/assets/AssetManager.js
@@ -647,21 +647,6 @@ export class AssetManager {
 	}
 
 	/**
-	 * @param {import("../../../src/mod.js").UuidString} uuid
-	 */
-	async getAssetPathFromUuid(uuid) {
-		await this.loadAssetSettings(true);
-		const asset = this.projectAssets.get(uuid);
-		if (!asset) {
-			if (this.builtInAssets.has(uuid)) {
-				throw new Error("Getting asset path from built-in assets is not supported.");
-			}
-			return null;
-		}
-		return asset.path.slice();
-	}
-
-	/**
 	 * @param {string[]} path1
 	 * @param {string[]} path2
 	 */

--- a/studio/src/preferences/autoRegisterPreferences.js
+++ b/studio/src/preferences/autoRegisterPreferences.js
@@ -82,7 +82,7 @@ const autoRegisterPreferences = /** @type {const} */ ({
 			},
 		},
 	}),
-	"buildView.selectedEntryPoint": pref({
+	"buildView.selectedScriptEntryPoint": pref({
 		type: "string",
 		allowedLocations: ["contentwindow-project"],
 		defaultLocation: "contentwindow-project",

--- a/studio/src/preferences/autoRegisterPreferences.js
+++ b/studio/src/preferences/autoRegisterPreferences.js
@@ -1,3 +1,7 @@
+import {ProjectAssetTypeEntity} from "../assets/projectAssetType/ProjectAssetTypeEntity.js";
+import {ProjectAssetTypeHtml} from "../assets/projectAssetType/ProjectAssetTypeHtml.js";
+import {ProjectAssetTypeJavascript} from "../assets/projectAssetType/ProjectAssetTypeJavascript.js";
+
 /**
  * Takes a preference type and returns it as const.
  * This only exists to make autocompletions work.
@@ -50,14 +54,42 @@ const autoRegisterPreferences = /** @type {const} */ ({
 		defaultLocation: "project",
 		allowedLocations: ["project"],
 	}),
-	"buildView.availableEntryPoints": pref({
-		type: "unknown",
+	"buildView.availableScriptEntryPoints": pref({
+		type: "gui",
 		allowedLocations: ["project", "version-control", "contentwindow-project"],
 		defaultLocation: "version-control",
+		guiOpts: {
+			type: "array",
+			guiOpts: {
+				arrayType: "droppable",
+				arrayGuiOpts: {
+					supportedAssetTypes: [ProjectAssetTypeHtml, ProjectAssetTypeJavascript],
+				},
+			},
+		},
+	}),
+	"buildView.availableEntityEntryPoints": pref({
+		type: "gui",
+		allowedLocations: ["project", "version-control", "contentwindow-project"],
+		defaultLocation: "version-control",
+		guiOpts: {
+			type: "array",
+			guiOpts: {
+				arrayType: "droppable",
+				arrayGuiOpts: {
+					supportedAssetTypes: [ProjectAssetTypeEntity],
+				},
+			},
+		},
 	}),
 	"buildView.selectedEntryPoint": pref({
 		type: "string",
-		allowedLocations: ["project", "version-control", "contentwindow-project"],
+		allowedLocations: ["contentwindow-project"],
+		defaultLocation: "contentwindow-project",
+	}),
+	"buildView.selectedEntityEntryPoint": pref({
+		type: "string",
+		allowedLocations: ["contentwindow-project"],
 		defaultLocation: "contentwindow-project",
 	}),
 });

--- a/studio/src/tasks/task/TaskBundleScripts.js
+++ b/studio/src/tasks/task/TaskBundleScripts.js
@@ -85,9 +85,12 @@ export class TaskBundleScripts extends Task {
 		const assetManager = this.studioInstance.projectManager.assertAssetManagerExists();
 		const inputPaths = [];
 		for (const entryPoint of entryPoints) {
-			const path = await assetManager.getAssetPathFromUuid(entryPoint);
-			if (path) {
-				inputPaths.push(path.join("/"));
+			const asset = await assetManager.getProjectAssetFromUuid(entryPoint);
+			if (asset) {
+				if (asset.isBuiltIn) {
+					throw new Error("Bundling built-in script assets are not yet supported.");
+				}
+				inputPaths.push(asset.path.join("/"));
 			}
 		}
 		const result = await this.#messenger.send.bundle({

--- a/studio/src/ui/ButtonGroup.js
+++ b/studio/src/ui/ButtonGroup.js
@@ -41,13 +41,22 @@ export class ButtonGroup {
 	}
 
 	/**
-	 * @param {number} buttonIndex
+	 * @param {import("./Button.js").Button | number} buttonOrIndex
 	 */
-	removeButton(buttonIndex) {
-		const button = this.buttons[buttonIndex];
-		if (!button) return;
+	removeButton(buttonOrIndex) {
+		let button;
+		let index;
+		if (typeof buttonOrIndex == "number") {
+			button = this.buttons[buttonOrIndex];
+			index = buttonOrIndex;
+			if (!button) return;
+		} else {
+			button = buttonOrIndex;
+			index = this.buttons.indexOf(button);
+			if (index == -1) return;
+		}
 
-		this.buttons.splice(buttonIndex, 1);
+		this.buttons.splice(index, 1);
 		this.el.removeChild(button.el);
 		button.removeOnContextMenu(this.boundFireContextMenuCbs);
 		button.removeOnVisibilityChange(this.#updateFirstLastButtonClasses);

--- a/studio/src/ui/ButtonSelectorGui.js
+++ b/studio/src/ui/ButtonSelectorGui.js
@@ -50,7 +50,7 @@ export class ButtonSelectorGui {
 	/** @type {Button[]} */
 	#buttons = [];
 	/** @type {ButtonSelectorGuiOptionsItem[]} */
-	#items = [];
+	items = [];
 	#buttonGroup;
 
 	/**
@@ -95,7 +95,7 @@ export class ButtonSelectorGui {
 			this.#buttonGroup.removeButton(button);
 		}
 		this.#buttons = [];
-		this.#items = items;
+		this.items = items;
 
 		for (const [i, item] of items.entries()) {
 			/** @type {import("./Button.js").ButtonGuiOptions} */
@@ -139,9 +139,9 @@ export class ButtonSelectorGui {
 		if (value == null) {
 			index = -1;
 		} else if (typeof value == "string") {
-			index = this.#items.indexOf(value);
+			index = this.items.indexOf(value);
 		} else {
-			if (value >= 0 && value < this.#items.length) {
+			if (value >= 0 && value < this.items.length) {
 				index = value;
 			} else {
 				index = -1;
@@ -193,7 +193,7 @@ export class ButtonSelectorGui {
 		if (getIndex) {
 			returnValue = getNullOrIndex();
 		} else {
-			const item = this.#items[this.currentValueIndex];
+			const item = this.items[this.currentValueIndex];
 			if (!item) {
 				returnValue = null;
 			} else if (typeof item == "string") {

--- a/studio/src/ui/ButtonSelectorGui.js
+++ b/studio/src/ui/ButtonSelectorGui.js
@@ -47,6 +47,12 @@ import {ButtonGroup} from "./ButtonGroup.js";
  * @template {boolean} [TAllowSelectNone = false]
  */
 export class ButtonSelectorGui {
+	/** @type {Button[]} */
+	#buttons = [];
+	/** @type {ButtonSelectorGuiOptionsItem[]} */
+	#items = [];
+	#buttonGroup;
+
 	/**
 	 * @param {ButtonSelectorGuiOptions} opts
 	 */
@@ -57,10 +63,6 @@ export class ButtonSelectorGui {
 		vertical = false,
 		disabled = false,
 	} = {}) {
-		if (items.length == 0) {
-			throw new Error("An empty array was provided. ButtonSelectorGuis must at least have one item.");
-		}
-		this.items = items;
 		this.allowSelectNone = allowSelectNone;
 		this.currentValueIndex = 0;
 		this.defaultValue = this.#valueToIndex(defaultValue);
@@ -69,9 +71,31 @@ export class ButtonSelectorGui {
 		}
 		this.disabled = disabled;
 
-		this.buttonGroup = new ButtonGroup({vertical});
-		this.el = this.buttonGroup.el;
-		this.buttons = [];
+		this.#buttonGroup = new ButtonGroup({vertical});
+		this.el = this.#buttonGroup.el;
+
+		/** @type {Set<OnButtonselectorGuiValueChange>} */
+		this.onValueChangeCbs = new Set();
+
+		this.setItems(items);
+		this.setValue(this.defaultValue, {trigger: "application"});
+	}
+
+	/**
+	 * Updates the list of available buttons.
+	 * @param {ButtonSelectorGuiOptionsItem[]} items
+	 */
+	setItems(items) {
+		if (items.length == 0) {
+			throw new Error("An empty array was provided. ButtonSelectorGuis must at least have one item.");
+		}
+
+		for (const button of this.#buttons) {
+			button.destructor();
+			this.#buttonGroup.removeButton(button);
+		}
+		this.#buttons = [];
+		this.#items = items;
 
 		for (const [i, item] of items.entries()) {
 			/** @type {import("./Button.js").ButtonGuiOptions} */
@@ -95,18 +119,14 @@ export class ButtonSelectorGui {
 				};
 			}
 			const button = new Button(opts);
-			this.buttons.push(button);
-			this.buttonGroup.addButton(button);
+			this.#buttons.push(button);
+			this.#buttonGroup.addButton(button);
 		}
-
-		/** @type {Set<OnButtonselectorGuiValueChange>} */
-		this.onValueChangeCbs = new Set();
-
-		this.setValue(this.defaultValue, {trigger: "application"});
+		this.setValue(this.allowSelectNone ? null : 0, {trigger: "application"});
 	}
 
-	updateSelectedButton() {
-		for (const [i, button] of this.buttons.entries()) {
+	#updateSelectedButton() {
+		for (const [i, button] of this.#buttons.entries()) {
 			button.setSelectedHighlight(i == this.currentValueIndex);
 		}
 	}
@@ -119,9 +139,9 @@ export class ButtonSelectorGui {
 		if (value == null) {
 			index = -1;
 		} else if (typeof value == "string") {
-			index = this.items.indexOf(value);
+			index = this.#items.indexOf(value);
 		} else {
-			if (value >= 0 && value < this.items.length) {
+			if (value >= 0 && value < this.#items.length) {
 				index = value;
 			} else {
 				index = -1;
@@ -141,7 +161,7 @@ export class ButtonSelectorGui {
 			throw new Error(`"${value}" is not a valid value for this selector gui.`);
 		}
 		this.currentValueIndex = newValue;
-		this.updateSelectedButton();
+		this.#updateSelectedButton();
 		this.fireOnChangeCbs(trigger);
 	}
 
@@ -166,20 +186,20 @@ export class ButtonSelectorGui {
 		if (purpose == "binarySerialization") {
 			getIndex = /** @type {I} */ (true);
 		}
-		const getNullIndex = () => {
+		const getNullOrIndex = () => {
 			if (this.currentValueIndex == -1) return null;
 			return this.currentValueIndex;
 		};
 		if (getIndex) {
-			returnValue = getNullIndex();
+			returnValue = getNullOrIndex();
 		} else {
-			const item = this.items[this.currentValueIndex];
+			const item = this.#items[this.currentValueIndex];
 			if (!item) {
 				returnValue = null;
 			} else if (typeof item == "string") {
 				returnValue = item;
 			} else {
-				returnValue = getNullIndex();
+				returnValue = getNullOrIndex();
 			}
 		}
 		return /** @type {ButtonSelectorGuiGetValueReturn<TAllowSelectNone, I, P>} */ (returnValue);

--- a/studio/src/ui/propertiesTreeView/PropertiesTreeViewEntry.js
+++ b/studio/src/ui/propertiesTreeView/PropertiesTreeViewEntry.js
@@ -66,6 +66,7 @@ export class PropertiesTreeViewEntry extends TreeView {
 	constructor({
 		type,
 		guiOpts = {},
+		forceMultiLine = false,
 		callbacksContext = {},
 		tooltip = "",
 	}) {
@@ -78,6 +79,7 @@ export class PropertiesTreeViewEntry extends TreeView {
 		if (!this.customEl) throw new Error("Assertion failed, PropertiesTreeViewEntry should always have a customEl.");
 
 		this.customEl.classList.add("gui-tree-view-entry");
+		this.customEl.classList.toggle("multi-line", forceMultiLine);
 
 		const hideLabel = guiOpts.hideLabel ?? false;
 		const useLabelTag = type == "boolean";

--- a/studio/src/ui/propertiesTreeView/types.ts
+++ b/studio/src/ui/propertiesTreeView/types.ts
@@ -191,6 +191,12 @@ export type PropertiesTreeViewEntryOptionsGeneric<T extends GuiTypes, TOpts = an
 	 * The tooltip that is shown when hovering over the treeview item.
 	 */
 	tooltip?: string;
+	/**
+	 * When true, the entry label and the gui element will always be rendered below each other instead of side by side.
+	 * Normally, this only happens when the screen is too small to fit the two elements side by side.
+	 * Some gui types such as array guis are always rendered on two lines.
+	 */
+	forceMultiLine?: boolean;
 } : never;
 export type PropertiesTreeViewEntryOptions = PropertiesTreeViewEntryOptionsGeneric<GuiTypes>;
 

--- a/studio/src/windowManagement/contentWindows/ContentWindow.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindow.js
@@ -213,8 +213,12 @@ export class ContentWindow {
 	 * The preferences button opens a popover with the provided list of preferences.
 	 * This can only be called once for each content window.
 	 * @param {import("../../preferences/autoRegisterPreferences.js").AutoRegisterPreferenceTypes[]} preferenceIds
+	 * @param {object} [options]
+	 * @param {boolean} [options.needsCurtain]
 	 */
-	addPreferencesButton(...preferenceIds) {
+	addPreferencesButton(preferenceIds, {
+		needsCurtain = true,
+	} = {}) {
 		if (this.#preferencesButton) {
 			throw new Error("A preferences button has already been added.");
 		}
@@ -223,7 +227,9 @@ export class ContentWindow {
 			icon: "static/icons/preferences.svg",
 			colorizerFilterManager: this.studioInstance.colorizerFilterManager,
 		}, () => {
-			return this.studioInstance.popoverManager.addPopover(PreferencesPopover, this.studioInstance.preferencesManager, preferenceIds, this.uuid);
+			const popover = this.studioInstance.popoverManager.addPopover(PreferencesPopover, this.studioInstance.preferencesManager, preferenceIds, this.uuid);
+			popover.setNeedsCurtain(needsCurtain);
+			return popover;
 		});
 
 		this.#preferencesButton = button;

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -1,7 +1,7 @@
 import {ContentWindow} from "../ContentWindow.js";
 import {Button} from "../../../ui/Button.js";
 import {ButtonGroup} from "../../../ui/ButtonGroup.js";
-import {EntryPointPopover, getSelectedEntryPoint} from "./EntryPointPopover.js";
+import {EntryPointPopover, getSelectedScriptEntryPoint} from "./EntryPointPopover.js";
 import {TypedMessenger} from "../../../../../src/util/TypedMessenger.js";
 import {ProjectAssetTypeJavascript} from "../../../assets/projectAssetType/ProjectAssetTypeJavascript.js";
 import {ProjectAssetTypeHtml} from "../../../assets/projectAssetType/ProjectAssetTypeHtml.js";
@@ -140,7 +140,7 @@ export class ContentWindowBuildView extends ContentWindow {
 			if (!assetManager) {
 				throw new Error("Assertion failed, no asset manager");
 			}
-			const entryPointUuid = getSelectedEntryPoint(this.studioInstance.preferencesManager, this.uuid);
+			const entryPointUuid = getSelectedScriptEntryPoint(this.studioInstance.preferencesManager, this.uuid);
 			if (!entryPointUuid) {
 				throw new Error("Assertion failed, no entry point has been selected");
 			}

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -148,18 +148,25 @@ export class ContentWindowBuildView extends ContentWindow {
 				assertAssetType: [ProjectAssetTypeJavascript, ProjectAssetTypeHtml],
 				assertExists: true,
 			});
-			const path = projectAsset.path;
-			if (!path) {
+			const assetPath = projectAsset.path;
+			if (!assetPath) {
 				throw new Error("Assertion failed, selected entry point doesn't exist or has been removed.");
 			}
 			const clientId = await this.studioInstance.serviceWorkerManager.getClientId();
+			let path;
+			if (projectAsset.isBuiltIn) {
+				path = `builtinAssets/${assetPath.join("/")}`;
+			} else {
+				path = `sw/clients/${clientId}/projectFiles/${assetPath.join("/")}`;
+			}
+
 			const projectAssetType = await projectAsset.getProjectAssetType();
 			const projectAssetTypeAny = /** @type {any} */ (projectAssetType);
 			let newSrc;
 			if (projectAssetTypeAny instanceof ProjectAssetTypeHtml) {
-				newSrc = `sw/clients/${clientId}/projectFiles/${path.join("/")}`;
+				newSrc = path;
 			} else if (projectAssetTypeAny instanceof ProjectAssetTypeJavascript) {
-				newSrc = `sw/clients/${clientId}/getGeneratedHtml?scriptSrc=projectFiles/${path.join("/")}`;
+				newSrc = `sw/clients/${clientId}/getGeneratedHtml?scriptSrc=/studio/${path}`;
 			} else {
 				throw new Error(`Unexpected asset type for project asset with uuid "${entryPointUuid}"`);
 			}

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -23,6 +23,13 @@ export class ContentWindowBuildView extends ContentWindow {
 	constructor(...args) {
 		super(...args);
 
+		this.addPreferencesButton([
+			"buildView.availableEntityEntryPoints",
+			"buildView.availableScriptEntryPoints",
+		], {
+			needsCurtain: false,
+		});
+
 		this.setContentBehindTopBar(true);
 
 		this.isRunning = false;

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -44,7 +44,7 @@ function getEntityEntryPointsPreference(preferencesManager, contentWindowUuid) {
  * @returns {import("../../../../../src/mod.js").UuidString?}
  */
 export function getSelectedEntryPoint(preferencesManager, contentWindowUuid) {
-	const selectedUuid = preferencesManager.get("buildView.selectedEntryPoint", contentWindowUuid);
+	const selectedUuid = preferencesManager.get("buildView.selectedScriptEntryPoint", contentWindowUuid);
 	if (selectedUuid && typeof selectedUuid == "string") {
 		return selectedUuid;
 	}
@@ -85,7 +85,7 @@ export class EntryPointPopover extends Popover {
 			entryPointUuids: entityEntryPointUuids,
 		});
 		this.#createSelector({
-			selectedPreferenceId: "buildView.selectedEntryPoint",
+			selectedPreferenceId: "buildView.selectedScriptEntryPoint",
 			label: "Script",
 			tooltip: "The script that will be loaded when pressing play. By default, a script with basic functionality is used. You can add additional entry points in the preferences menu.",
 			defaultText: "Default",

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -1,6 +1,8 @@
 import {Popover} from "../../../ui/popoverMenus/Popover.js";
 import {PropertiesTreeView} from "../../../ui/propertiesTreeView/PropertiesTreeView.js";
 
+export const BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID = "5a328430-e3bc-4eda-afab-789f00439f81";
+
 /**
  * @param {import("../../../Studio.js").Studio["preferencesManager"]} preferencesManager
  * @param {import("../../../../../src/mod.js").UuidString} contentWindowUuid
@@ -43,12 +45,12 @@ function getEntityEntryPointsPreference(preferencesManager, contentWindowUuid) {
  * @returns {import("../../../../../src/mod.js").UuidString?}
  */
 export function getSelectedScriptEntryPoint(preferencesManager, contentWindowUuid) {
+	const entryPoints = getEntryPointsPreference(preferencesManager, contentWindowUuid);
 	const selectedUuid = preferencesManager.get("buildView.selectedScriptEntryPoint", contentWindowUuid);
-	if (selectedUuid && typeof selectedUuid == "string") {
+	if (selectedUuid && typeof selectedUuid == "string" && entryPoints.includes(selectedUuid)) {
 		return selectedUuid;
 	}
-	const entryPoints = getEntryPointsPreference(preferencesManager, contentWindowUuid);
-	return entryPoints[0] || null;
+	return BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID;
 }
 
 /**

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -146,10 +146,10 @@ export class EntryPointPopover extends Popover {
 			/** @type {Set<string>} */
 			const duplicateFileNames = new Set();
 			for (const uuid of entryPointUuids) {
-				const path = await this.#assetManager.getAssetPathFromUuid(uuid);
-				if (!path) continue;
-				const fullPath = path.join("/");
-				const fileName = path.at(-1) || "";
+				const asset = await this.#assetManager.getProjectAssetFromUuid(uuid);
+				if (!asset) continue;
+				const fullPath = asset.path.join("/");
+				const fileName = asset.path.at(-1) || "";
 				itemDatas.push({uuid, fullPath, fileName});
 				if (fileNames.has(fileName)) {
 					duplicateFileNames.add(fileName);

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js
@@ -1,4 +1,3 @@
-import {ButtonSelectorGui} from "../../../ui/ButtonSelectorGui.js";
 import {Popover} from "../../../ui/popoverMenus/Popover.js";
 import {PropertiesTreeView} from "../../../ui/propertiesTreeView/PropertiesTreeView.js";
 
@@ -43,8 +42,22 @@ function getEntityEntryPointsPreference(preferencesManager, contentWindowUuid) {
  * @param {import("../../../../../src/mod.js").UuidString} contentWindowUuid
  * @returns {import("../../../../../src/mod.js").UuidString?}
  */
-export function getSelectedEntryPoint(preferencesManager, contentWindowUuid) {
+export function getSelectedScriptEntryPoint(preferencesManager, contentWindowUuid) {
 	const selectedUuid = preferencesManager.get("buildView.selectedScriptEntryPoint", contentWindowUuid);
+	if (selectedUuid && typeof selectedUuid == "string") {
+		return selectedUuid;
+	}
+	const entryPoints = getEntryPointsPreference(preferencesManager, contentWindowUuid);
+	return entryPoints[0] || null;
+}
+
+/**
+ * @param {import("../../../Studio.js").Studio["preferencesManager"]} preferencesManager
+ * @param {import("../../../../../src/mod.js").UuidString} contentWindowUuid
+ * @returns {import("../../../../../src/mod.js").UuidString?}
+ */
+export function getSelectedEntityEntryPoint(preferencesManager, contentWindowUuid) {
+	const selectedUuid = preferencesManager.get("buildView.selectedEntityEntryPoint", contentWindowUuid);
 	if (selectedUuid && typeof selectedUuid == "string") {
 		return selectedUuid;
 	}
@@ -56,7 +69,6 @@ export class EntryPointPopover extends Popover {
 	#assetManager;
 	#preferencesManager;
 	#contentWindowUuid;
-	#treeView;
 
 	/**
 	 * @param {ConstructorParameters<typeof Popover>[0]} popoverManager
@@ -71,8 +83,8 @@ export class EntryPointPopover extends Popover {
 		this.#preferencesManager = preferencesManager;
 		this.#contentWindowUuid = contentWindowUuid;
 
-		this.#treeView = new PropertiesTreeView();
-		this.el.appendChild(this.#treeView.el);
+		this.treeView = new PropertiesTreeView();
+		this.el.appendChild(this.treeView.el);
 
 		const entityEntryPointUuids = getEntityEntryPointsPreference(this.#preferencesManager, this.#contentWindowUuid);
 		const entryPointUuids = getEntryPointsPreference(this.#preferencesManager, this.#contentWindowUuid);
@@ -102,7 +114,7 @@ export class EntryPointPopover extends Popover {
 	 * @param {import("../../../../../src/mod.js").UuidString[]} options.entryPointUuids
 	 */
 	#createSelector({selectedPreferenceId, label, tooltip, defaultText, entryPointUuids}) {
-		const entry = this.#treeView.addItem({
+		const entry = this.treeView.addItem({
 			type: "buttonSelector",
 			guiOpts: {
 				label,

--- a/studio/src/windowManagement/contentWindows/ContentWindowConnections.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowConnections.js
@@ -21,7 +21,7 @@ export class ContentWindowConnections extends ContentWindow {
 
 		this.addPreferencesButton([
 			"studioConnections.allowInternalIncoming",
-			"studioConnections.allowRemoteIncoming"
+			"studioConnections.allowRemoteIncoming",
 		]);
 
 		this.headerTreeView = new PropertiesTreeView();

--- a/studio/src/windowManagement/contentWindows/ContentWindowConnections.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowConnections.js
@@ -19,10 +19,10 @@ export class ContentWindowConnections extends ContentWindow {
 	constructor(...args) {
 		super(...args);
 
-		this.addPreferencesButton(
+		this.addPreferencesButton([
 			"studioConnections.allowInternalIncoming",
 			"studioConnections.allowRemoteIncoming"
-		);
+		]);
 
 		this.headerTreeView = new PropertiesTreeView();
 		this.contentEl.appendChild(this.headerTreeView.el);

--- a/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/ContentWindowEntityEditor.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowEntityEditor/ContentWindowEntityEditor.js
@@ -39,12 +39,12 @@ export class ContentWindowEntityEditor extends ContentWindow {
 
 		this.setContentBehindTopBar(true);
 
-		this.addPreferencesButton(
+		this.addPreferencesButton([
 			"entityEditor.autosaveEntities",
 			"entityEditor.invertScrollOrbitX",
 			"entityEditor.invertScrollOrbitY",
-			"entityEditor.showGrid"
-		);
+			"entityEditor.showGrid",
+		]);
 
 		this.entitySavingManager = new EntitySavingManager(this.studioInstance, this);
 		this.addTopBarEl(this.entitySavingManager.saveEntityButton.el);

--- a/test/unit/studio/src/assets/AssetManager/misc.test.js
+++ b/test/unit/studio/src/assets/AssetManager/misc.test.js
@@ -175,14 +175,3 @@ testTypes({
 		assertIsType(true, uuid2);
 	},
 });
-
-Deno.test({
-	name: "getAssetPathFromUuid()",
-	async fn() {
-		const {assetManager} = await basicSetup();
-
-		const path = await assetManager.getAssetPathFromUuid(BASIC_ASSET_UUID);
-
-		assertEquals(path, BASIC_ASSET_PATH);
-	},
-});

--- a/test/unit/studio/src/ui/ButtonGroup.test.js
+++ b/test/unit/studio/src/ui/ButtonGroup.test.js
@@ -16,7 +16,14 @@ Deno.test({
 			const button3 = new Button();
 			group.addButton(button3);
 
-			assertEquals(group.el.childElementCount, 3);
+			/**
+			 * @param {number} childCount
+			 */
+			function testChildCount(childCount) {
+				assertEquals(group.el.childElementCount, childCount);
+			}
+
+			testChildCount(3);
 
 			/**
 			 * @param {string} className
@@ -61,10 +68,28 @@ Deno.test({
 			group.removeButton(0);
 			testClasses("first-visible-child", [true, true, false]);
 			testClasses("last-visible-child", [false, false, true]);
+			testChildCount(2);
 
 			group.removeButton(10); // doesn't exist: no-op
 			testClasses("first-visible-child", [true, true, false]);
 			testClasses("last-visible-child", [false, false, true]);
+			testChildCount(2);
+
+			group.removeButton(button2);
+			testClasses("first-visible-child", [true, true, true]);
+			testClasses("last-visible-child", [false, false, true]);
+			testChildCount(1);
+
+			group.removeButton(button1); // Already removed: no-op
+			testClasses("first-visible-child", [true, true, true]);
+			testClasses("last-visible-child", [false, false, true]);
+			testChildCount(1);
+
+			const nonExistentButton = new Button();
+			group.removeButton(nonExistentButton); // doesn't exist: no-op
+			testClasses("first-visible-child", [true, true, true]);
+			testClasses("last-visible-child", [false, false, true]);
+			testChildCount(1);
 		});
 	},
 });

--- a/test/unit/studio/src/ui/ButtonSelectorGui.test.js
+++ b/test/unit/studio/src/ui/ButtonSelectorGui.test.js
@@ -18,6 +18,19 @@ function createOnChangeSpy(gui) {
 	return spyFn;
 }
 
+/**
+ * @param {ButtonSelectorGui} gui
+ * @param {boolean[]} highlights
+ */
+function testSelectedHighlights(gui, highlights) {
+	assertEquals(gui.el.childElementCount, highlights.length);
+	for (let i = 0; i < highlights.length; i++) {
+		const button = gui.el.children[i];
+		const highlight = highlights[i];
+		assertEquals(button.classList.contains("selected"), highlight);
+	}
+}
+
 Deno.test({
 	name: "allowSelectNone true",
 	fn() {
@@ -199,7 +212,7 @@ Deno.test({
 });
 
 Deno.test({
-	name: "list of items",
+	name: "Clicking buttons",
 	fn() {
 		runWithDom(() => {
 			const gui = new ButtonSelectorGui({
@@ -388,6 +401,137 @@ Deno.test({
 			assertThrows(() => {
 				gui2.setValue(100);
 			}, Error, `100" is not a valid value for this selector gui`);
+		});
+	},
+});
+
+Deno.test({
+	name: "setItems()",
+	fn() {
+		runWithDom(() => {
+			const gui = new ButtonSelectorGui({
+				items: [
+					"First",
+					"Second",
+				],
+			});
+			const spyFn = createOnChangeSpy(gui);
+
+			assertEquals(gui.value, "First");
+			testSelectedHighlights(gui, [true, false]);
+
+			gui.setValue("Second");
+			assertSpyCalls(spyFn, 1);
+			assertSpyCall(spyFn, 0, {
+				args: [
+					{
+						value: "Second",
+						trigger: "application",
+					},
+				],
+			});
+			testSelectedHighlights(gui, [false, true]);
+
+			gui.setItems([
+				"First",
+				"Second",
+				"Third",
+			]);
+
+			assertSpyCalls(spyFn, 2);
+			assertSpyCall(spyFn, 1, {
+				args: [
+					{
+						value: "First",
+						trigger: "application",
+					},
+				],
+			});
+			assertEquals(gui.value, "First");
+			testSelectedHighlights(gui, [true, false, false]);
+
+			gui.setItems([
+				"Different",
+				"Also different",
+			]);
+
+			assertSpyCalls(spyFn, 3);
+			assertSpyCall(spyFn, 2, {
+				args: [
+					{
+						value: "Different",
+						trigger: "application",
+					},
+				],
+			});
+			assertEquals(gui.value, "Different");
+			testSelectedHighlights(gui, [true, false]);
+		});
+	},
+});
+
+Deno.test({
+	name: "setItems() with allowSelectNone: true",
+	fn() {
+		runWithDom(() => {
+			const gui = new ButtonSelectorGui({
+				items: [
+					"First",
+					"Second",
+				],
+				allowSelectNone: true,
+			});
+			const spyFn = createOnChangeSpy(gui);
+
+			assertEquals(gui.value, null);
+			testSelectedHighlights(gui, [false, false]);
+
+			gui.setValue("Second");
+			assertSpyCalls(spyFn, 1);
+			assertSpyCall(spyFn, 0, {
+				args: [
+					{
+						value: "Second",
+						trigger: "application",
+					},
+				],
+			});
+			testSelectedHighlights(gui, [false, true]);
+
+			gui.setItems([
+				"First",
+				"Second",
+				"Third",
+			]);
+
+			assertSpyCalls(spyFn, 2);
+			assertSpyCall(spyFn, 1, {
+				args: [
+					{
+						value: null,
+						trigger: "application",
+					},
+				],
+			});
+			assertEquals(gui.value, null);
+			testSelectedHighlights(gui, [false, false, false]);
+
+			gui.setItems([
+				"Different",
+				"Also different",
+			]);
+
+			assertSpyCalls(spyFn, 3);
+			assertSpyCall(spyFn, 2, {
+				args: [
+					{
+						value: null,
+						trigger: "application",
+					},
+				],
+			});
+			assertEquals(gui.value, null);
+			testSelectedHighlights(gui, [false, false]);
 		});
 	},
 });

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindow/preferencesButton.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindow/preferencesButton.test.js
@@ -45,7 +45,7 @@ Deno.test({
 			const contentWindow = new ContentWindow(mockStudioInstance, mockWindowManager, "uuid");
 
 			const ids = /** @type {any[]} */ (["id1", "id2"]);
-			contentWindow.addPreferencesButton(...ids);
+			contentWindow.addPreferencesButton(ids);
 
 			const preferencesButton = contentWindow.topButtonBar.children[1];
 			assertExists(preferencesButton);
@@ -64,7 +64,7 @@ Deno.test({
 			});
 
 			assertThrows(() => {
-				contentWindow.addPreferencesButton();
+				contentWindow.addPreferencesButton([]);
 			}, Error, "A preferences button has already been added.");
 		});
 	},

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindow/preferencesButton.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindow/preferencesButton.test.js
@@ -3,24 +3,10 @@ import {runWithDom} from "../../../../shared/runWithDom.js";
 import {MouseEvent} from "fake-dom/FakeMouseEvent.js";
 import {HtmlElement} from "fake-dom/FakeHtmlElement.js";
 import {PreferencesManager} from "../../../../../../../studio/src/preferences/PreferencesManager.js";
-import {Importer} from "fake-imports";
 import {assertExists, assertInstanceOf, assertThrows} from "std/testing/asserts.ts";
 import {assertSpyCall, assertSpyCalls, spy} from "std/testing/mock.ts";
-
-const importer = new Importer(import.meta.url);
-importer.makeReal("../../../../../../../studio/src/studioInstance.js");
-importer.makeReal("../../../../../../../studio/src/ui/popoverMenus/popoverToggleButton.js");
-importer.fakeModule("../../../../../../../studio/src/windowManagement/PreferencesPopover.js", `
-export class PreferencesPopover {}
-`);
-
-/** @type {import("../../../../../../../studio/src/windowManagement/contentWindows/ContentWindow.js")} */
-const ContentWindowMod = await importer.import("../../../../../../../studio/src/windowManagement/contentWindows/ContentWindow.js");
-const {ContentWindow} = ContentWindowMod;
-
-/** @type {import("../../../../../../../studio/src/windowManagement/PreferencesPopover.js")} */
-const PreferencesPopoverMod = await importer.import("../../../../../../../studio/src/windowManagement/PreferencesPopover.js");
-const {PreferencesPopover} = PreferencesPopoverMod;
+import {ContentWindow} from "../../../../../../../studio/src/windowManagement/contentWindows/ContentWindow.js";
+import {PreferencesPopover} from "../../../../../../../studio/src/windowManagement/PreferencesPopover.js";
 
 Deno.test({
 	name: "Preferences Button opens a preferences popover",
@@ -34,6 +20,7 @@ Deno.test({
 					addPopover() {
 						return {
 							setPos() {},
+							setNeedsCurtain(needsCurtain) {},
 						};
 					},
 				},

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
@@ -52,20 +52,24 @@ function basicTest() {
 	preferencesManager.addLocation(preferencesLocation);
 
 	const assetManager = /** @type {import("../../../../../../../studio/src/assets/AssetManager.js").AssetManager} */ ({
-		async getAssetPathFromUuid(uuid) {
+		async getProjectAssetFromUuid(uuid) {
+			let path;
 			if (uuid == ENTRY_POINT_UUID_1) {
-				return ["path", "to", "asset1.json"];
+				path = ["path", "to", "asset1.json"];
 			} else if (uuid == ENTRY_POINT_UUID_2) {
-				return ["path", "to", "asset2.json"];
+				path = ["path", "to", "asset2.json"];
 			} else if (uuid == ENTRY_POINT_UUID_3) {
-				return ["path", "with", "same", "filename.json"];
+				path = ["path", "with", "same", "filename.json"];
 			} else if (uuid == ENTRY_POINT_UUID_4) {
-				return ["other", "path", "with", "same", "filename.json"];
+				path = ["other", "path", "with", "same", "filename.json"];
 			} else if (uuid == ENTRY_POINT_UUID_5) {
 				// Non existent assets shouldn't show up in the list
 				return null;
 			}
-			return null;
+			if (!path) return null;
+			return /** @type {import("../../../../../../../studio/src/assets/ProjectAsset.js").ProjectAssetAny} */ ({
+				path,
+			});
 		},
 	});
 

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
@@ -298,5 +298,5 @@ Deno.test({
 		} finally {
 			uninstall();
 		}
-	}
-})
+	},
+});

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
@@ -2,7 +2,7 @@ import {assertEquals, assertInstanceOf} from "std/testing/asserts.ts";
 import {PreferencesManager} from "../../../../../../../studio/src/preferences/PreferencesManager.js";
 import {ContentWindowPreferencesLocation} from "../../../../../../../studio/src/preferences/preferencesLocation/ContentWindowPreferencesLocation.js";
 import {injectMockStudioInstance} from "../../../../../../../studio/src/studioInstance.js";
-import {EntryPointPopover, getSelectedEntityEntryPoint, getSelectedScriptEntryPoint} from "../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js";
+import {BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID, EntryPointPopover, getSelectedEntityEntryPoint, getSelectedScriptEntryPoint} from "../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.js";
 import {installFakeDocument, uninstallFakeDocument} from "fake-dom/FakeDocument.js";
 import {PreferencesLocation} from "../../../../../../../studio/src/preferences/preferencesLocation/PreferencesLocation.js";
 import {waitForMicrotasks} from "../../../../../shared/waitForMicroTasks.js";
@@ -269,3 +269,34 @@ Deno.test({
 		}
 	},
 });
+
+Deno.test({
+	name: "getSelectedScriptEntryPoint() returns the right value",
+	fn() {
+		const {preferencesManager, uninstall} = basicTest();
+		try {
+			preferencesManager.set("buildView.availableScriptEntryPoints", [
+				ENTRY_POINT_UUID_1,
+				ENTRY_POINT_UUID_2,
+			]);
+
+			// When no entry point has been selected, it should return the built in asset uuid.
+			preferencesManager.reset("buildView.selectedScriptEntryPoint");
+			assertEquals(getSelectedScriptEntryPoint(preferencesManager, DEFAULT_CONTENT_WINDOW_UUID), BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID);
+
+			// Same for an empty string
+			preferencesManager.set("buildView.selectedScriptEntryPoint", "");
+			assertEquals(getSelectedScriptEntryPoint(preferencesManager, DEFAULT_CONTENT_WINDOW_UUID), BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID);
+
+			// But when it has been selected, it should return that uuid
+			preferencesManager.set("buildView.selectedScriptEntryPoint", ENTRY_POINT_UUID_2);
+			assertEquals(getSelectedScriptEntryPoint(preferencesManager, DEFAULT_CONTENT_WINDOW_UUID), ENTRY_POINT_UUID_2);
+
+			// Unless that uuid does not exist in the buildView.availableScriptEntryPoints list.
+			preferencesManager.set("buildView.selectedScriptEntryPoint", ENTRY_POINT_UUID_3);
+			assertEquals(getSelectedScriptEntryPoint(preferencesManager, DEFAULT_CONTENT_WINDOW_UUID), BASIC_SCRIPT_ENTRY_POINT_BUILTIN_ASSET_UUID);
+		} finally {
+			uninstall();
+		}
+	}
+})

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/EntryPointPopover.test.js
@@ -19,7 +19,7 @@ function basicTest() {
 	const windowManager = /** @type {import("../../../../../../../studio/src/windowManagement/WindowManager.js").WindowManager} */ ({});
 
 	const preferencesManager = new PreferencesManager({
-		"buildView.availableEntryPoints": {
+		"buildView.availableScriptEntryPoints": {
 			type: "unknown",
 		},
 		"buildView.selectedEntryPoint": {


### PR DESCRIPTION
Fixes #741
Fixes #626

- [x] Add new entry point preferences
- [x] Support for changing the current entries in a ButtonSelectorGui
- [x] Change entry point popover to use a PropertiesTreeView with two button selector guis
- [x] Use the new preferences for the iframe url
- [ ] Introduce a way to postMessage the entity entry point to the iframe
- [x] Add a built-in asset for the default script
- [ ] Improve the built-in default script