### PR TITLE
feat!: Swap the TypedMessenger generic parameters

### DIFF
--- a/src/inspector/InternalDiscoveryManager.js
+++ b/src/inspector/InternalDiscoveryManager.js
@@ -79,7 +79,7 @@ export class InternalDiscoveryManager {
 
 		/**
 		 * The messenger between whatever page instantiated the InternalDiscoveryManager and the iframe it created.
-		 * @private @type {TypedMessenger<import("../../studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js").InternalDiscoveryIframeHandlers, InternalDiscoveryParentHandlers>}
+		 * @private @type {TypedMessenger<InternalDiscoveryParentHandlers, import("../../studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js").InternalDiscoveryIframeHandlers>}
 		 */
 		this.iframeMessenger = new TypedMessenger();
 		this.iframeMessenger.setResponseHandlers(this._getIframeRequestHandlers());
@@ -96,7 +96,7 @@ export class InternalDiscoveryManager {
 		 * The messenger between whatever page instantiated the InternalDiscoveryManager and the shared
 		 * worker that was created by the iframe. Messages first go through the iframe messenger which then
 		 * passes messages on to the sharedworker.
-		 * @private @type {TypedMessenger<import("../../studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js").InternalDiscoveryWorkerToParentHandlers, InternalDiscoveryParentWorkerHandlers>}
+		 * @private @type {TypedMessenger<InternalDiscoveryParentWorkerHandlers, import("../../studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js").InternalDiscoveryWorkerToParentHandlers>}
 		 */
 		this.workerMessenger = new TypedMessenger();
 		this.workerMessenger.setResponseHandlers(this._getWorkerResponseHandlers());
@@ -109,7 +109,7 @@ export class InternalDiscoveryManager {
 		 * parent window of that page. This exists to make it possible to communicate with studio and request
 		 * the url of the to be created iframe. If the page that created the InternalDiscoveryManager is not
 		 * in an iframe, this messenger is useless.
-		 * @private @type {TypedMessenger<import("../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers, {}>}
+		 * @private @type {TypedMessenger<{}, import("../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers>}
 		 */
 		this.parentMessenger = new TypedMessenger();
 		this.parentMessenger.setSendHandler(data => {

--- a/src/util/TypedMessenger.js
+++ b/src/util/TypedMessenger.js
@@ -118,8 +118,24 @@
  * Type safety is built in, so changing message signatures on one end will
  * automatically result in emitted TypeScript errors on the other end.
  *
- * @template {TypedMessengerSignatures} TReq
- * @template {TypedMessengerSignatures} TRes
+ * To ensure type safety, pass the handlers to the generic parameters:
+ * @example
+ * ```ts
+ * import type {workerRequestHandlers} from "./yourWorkerOrServerFile";
+ * const myRequestHandlers = {
+ * 	// ...
+ * };
+ * const messenger = new TypedMessenger<typeof myRequestHandlers, typeof workerRequestHandlers>();
+ * ```
+ * Or when using JSDoc:
+ * @example
+ * ```js
+ * //** @ type {TypedMessenger<typeof myRequestHandlers, import("./yourWorkerOrServerFile").workerRequestHandlers>} * /
+ * const messenger = new TypedMessenger();
+ * ```
+ *
+ * @template {TypedMessengerSignatures} TRes The handlers of this messenger.
+ * @template {TypedMessengerSignatures} TReq The handlers of the other messenger.
  * @template {boolean} [TRequireHandlerReturnObjects = false]
  */
 export class TypedMessenger {
@@ -163,7 +179,7 @@ export class TypedMessenger {
 	 *
 	 * ```ts
 	 * import type {workerRequestHandlers} from "./yourWorkerOrServerFile";
-	 * const messenger = new TypedMessenger<typeof workerRequestHandlers, typeof myRequestHandlers>();
+	 * const messenger = new TypedMessenger<typeof myRequestHandlers, typeof workerRequestHandlers>();
 	 * ```
 	 *
 	 * Now your types are setup correctly, so when using `messenger.send` you will
@@ -452,7 +468,7 @@ export class TypedMessenger {
 	 * 	},
 	 * };
 	 *
-	 * const messenger = new TypedMessenger<typeof otherHandlers, myHandlers>();
+	 * const messenger = new TypedMessenger<myHandlers, typeof otherHandlers>();
 	 * messenger.setResponseHandlers(myHandlers);
 	 * ```
 	 *

--- a/src/util/TypedMessenger.js
+++ b/src/util/TypedMessenger.js
@@ -133,7 +133,6 @@
  * //** @ type {TypedMessenger<typeof myRequestHandlers, import("./yourWorkerOrServerFile").workerRequestHandlers>} * /
  * const messenger = new TypedMessenger();
  * ```
- *
  * @template {TypedMessengerSignatures} TRes The handlers of this messenger.
  * @template {TypedMessengerSignatures} TReq The handlers of the other messenger.
  * @template {boolean} [TRequireHandlerReturnObjects = false]

--- a/studio/src/misc/ServiceWorkerManager.js
+++ b/studio/src/misc/ServiceWorkerManager.js
@@ -74,7 +74,7 @@ export class ServiceWorkerManager {
 		this.registration = null;
 
 		if (this.supported) {
-			/** @type {TypedMessenger<import("../../sw.js").ServiceWorkerMessageHandlers, ServiceWorkerManagerMessageHandlers>} */
+			/** @type {TypedMessenger<ServiceWorkerManagerMessageHandlers, import("../../sw.js").ServiceWorkerMessageHandlers>} */
 			this.messenger = new TypedMessenger();
 			this.messenger.setSendHandler(async data => {
 				await navigator.serviceWorker.ready;

--- a/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
+++ b/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
@@ -51,10 +51,10 @@ export function initializeIframe(window) {
 		worker.port.close();
 	}
 
-	/** @type {TypedMessenger<import("./internalDiscoveryWorkerMain.js").InternalDiscoveryWorkerToIframeHandlers, InternalDiscoveryIframeWorkerHandlers>} */
+	/** @type {TypedMessenger<InternalDiscoveryIframeWorkerHandlers, import("./internalDiscoveryWorkerMain.js").InternalDiscoveryWorkerToIframeHandlers>} */
 	const workerTypedMessenger = new TypedMessenger();
 
-	/** @type {TypedMessenger<import("../../../../../src/inspector/InternalDiscoveryManager.js").InternalDiscoveryParentHandlers, InternalDiscoveryIframeHandlers>} */
+	/** @type {TypedMessenger<InternalDiscoveryIframeHandlers, import("../../../../../src/inspector/InternalDiscoveryManager.js").InternalDiscoveryParentHandlers>} */
 	const parentWindowTypedMessenger = new TypedMessenger();
 
 	const {parentToIframeHandlers, workerToIframeHandlers} = getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destructorFunction: destructor});

--- a/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js
+++ b/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js
@@ -113,9 +113,9 @@ function getResponseHandlers(port, iframeMessenger, parentWindowMessenger, activ
 	};
 }
 /** @typedef {ReturnType<getResponseHandlers>["iframeResponseHandlers"]} InternalDiscoveryWorkerToIframeHandlers */
-/** @typedef {TypedMessenger<import("./internalDiscoveryIframeMain.js").InternalDiscoveryIframeWorkerHandlers, InternalDiscoveryWorkerToIframeHandlers>} WorkerToIframeTypedMessengerType */
+/** @typedef {TypedMessenger<InternalDiscoveryWorkerToIframeHandlers, import("./internalDiscoveryIframeMain.js").InternalDiscoveryIframeWorkerHandlers>} WorkerToIframeTypedMessengerType */
 /** @typedef {ReturnType<getResponseHandlers>["parentWindowResponseHandlers"]} InternalDiscoveryWorkerToParentHandlers */
-/** @typedef {TypedMessenger<import("../../../../../src/inspector/InternalDiscoveryManager.js").InternalDiscoveryParentWorkerHandlers, InternalDiscoveryWorkerToParentHandlers>} WorkerToParentTypedMessengerType */
+/** @typedef {TypedMessenger<InternalDiscoveryWorkerToParentHandlers, import("../../../../../src/inspector/InternalDiscoveryManager.js").InternalDiscoveryParentWorkerHandlers>} WorkerToParentTypedMessengerType */
 
 /**
  * @param {typeof globalThis} workerGlobal

--- a/studio/src/tasks/task/TaskBuildApplication.js
+++ b/studio/src/tasks/task/TaskBuildApplication.js
@@ -33,7 +33,7 @@ export class TaskBuildApplication extends Task {
 		},
 	});
 
-	/** @type {TypedMessenger<import("../workers/buildApplication/mod.js").BuildApplicationMessengerResponseHandlers, BuildApplicationMessengerResponseHandlers, true>} */
+	/** @type {TypedMessenger<BuildApplicationMessengerResponseHandlers, import("../workers/buildApplication/mod.js").BuildApplicationMessengerResponseHandlers, true>} */
 	#messenger;
 
 	#lastContextId = 0;

--- a/studio/src/tasks/task/TaskBundleAssets.js
+++ b/studio/src/tasks/task/TaskBundleAssets.js
@@ -142,7 +142,7 @@ export class TaskBundleAssets extends Task {
 		},
 	});
 
-	/** @type {TypedMessenger<import("../workers/bundleAssets/mod.js").BundleAssetsMessengerResponseHandlers, BundleAssetsMessengerResponseHandlers, true>} */
+	/** @type {TypedMessenger<BundleAssetsMessengerResponseHandlers, import("../workers/bundleAssets/mod.js").BundleAssetsMessengerResponseHandlers, true>} */
 	#messenger;
 
 	#lastFileStreamId = 0;

--- a/studio/src/tasks/task/TaskBundleScripts.js
+++ b/studio/src/tasks/task/TaskBundleScripts.js
@@ -24,7 +24,7 @@ export class TaskBundleScripts extends Task {
 	// @rollup-plugin-resolve-url-objects
 	static workerUrl = new URL("../workers/bundleScripts/mod.js", import.meta.url);
 
-	/** @type {TypedMessenger<import("../workers/bundleScripts/mod.js").BundleScriptsMessengerResponseHandlers, BundleScriptsMessengerResponseHandlers>} */
+	/** @type {TypedMessenger<BundleScriptsMessengerResponseHandlers, import("../workers/bundleScripts/mod.js").BundleScriptsMessengerResponseHandlers>} */
 	#messenger;
 
 	#lastReadScriptCallbackId = 0;

--- a/studio/src/tasks/workers/buildApplication/mod.js
+++ b/studio/src/tasks/workers/buildApplication/mod.js
@@ -2,7 +2,7 @@ import {TypedMessenger} from "../../../../../src/util/TypedMessenger.js";
 
 /** @typedef {typeof responseHandlers} BuildApplicationMessengerResponseHandlers */
 
-/** @type {TypedMessenger<import("../../task/TaskBuildApplication.js").BuildApplicationMessengerResponseHandlers, BuildApplicationMessengerResponseHandlers, true>} */
+/** @type {TypedMessenger<BuildApplicationMessengerResponseHandlers, import("../../task/TaskBuildApplication.js").BuildApplicationMessengerResponseHandlers, true>} */
 const messenger = new TypedMessenger({returnTransferSupport: true});
 
 const responseHandlers = {

--- a/studio/src/tasks/workers/bundleAssets/mod.js
+++ b/studio/src/tasks/workers/bundleAssets/mod.js
@@ -4,7 +4,7 @@ import {bundle} from "./bundle.js";
 /** @typedef {typeof messenger} BundleScriptsMessenger */
 /** @typedef {typeof responseHandlers} BundleAssetsMessengerResponseHandlers */
 
-/** @type {TypedMessenger<import("../../task/TaskBundleAssets.js").BundleAssetsMessengerResponseHandlers, BundleAssetsMessengerResponseHandlers, true>} */
+/** @type {TypedMessenger<BundleAssetsMessengerResponseHandlers, import("../../task/TaskBundleAssets.js").BundleAssetsMessengerResponseHandlers, true>} */
 const messenger = new TypedMessenger({returnTransferSupport: true});
 
 const responseHandlers = {

--- a/studio/src/tasks/workers/bundleScripts/mod.js
+++ b/studio/src/tasks/workers/bundleScripts/mod.js
@@ -13,7 +13,7 @@ const responseHandlers = {
 	},
 };
 
-/** @type {TypedMessenger<import("../../task/TaskBundleScripts.js").BundleScriptsMessengerResponseHandlers, BundleScriptsMessengerResponseHandlers>} */
+/** @type {TypedMessenger<BundleScriptsMessengerResponseHandlers, import("../../task/TaskBundleScripts.js").BundleScriptsMessengerResponseHandlers>} */
 const messenger = new TypedMessenger();
 messenger.initialize(globalThis, responseHandlers);
 

--- a/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
+++ b/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js
@@ -37,7 +37,7 @@ export class ContentWindowBuildView extends ContentWindow {
 		this.iframeEl.classList.add("build-view-iframe");
 		this.contentEl.appendChild(this.iframeEl);
 
-		/** @type {TypedMessenger<{}, BuildViewIframeResponseHandlers>} */
+		/** @type {TypedMessenger<BuildViewIframeResponseHandlers, {}>} */
 		this.iframeMessenger = new TypedMessenger();
 		this.iframeMessenger.setResponseHandlers(this.getIframeResponseHandlers());
 		this.iframeMessenger.setSendHandler(data => {

--- a/studio/sw.js
+++ b/studio/sw.js
@@ -20,7 +20,7 @@ function getMessageHandlers(client) {
 }
 /** @typedef {ReturnType<getMessageHandlers>} ServiceWorkerMessageHandlers */
 
-/** @typedef {TypedMessenger<import("./src/misc/ServiceWorkerManager.js").ServiceWorkerManagerMessageHandlers, ServiceWorkerMessageHandlers>} TypedMessengerWithTypes */
+/** @typedef {TypedMessenger<ServiceWorkerMessageHandlers, import("./src/misc/ServiceWorkerManager.js").ServiceWorkerManagerMessageHandlers>} TypedMessengerWithTypes */
 
 /** @type {Map<string, TypedMessengerWithTypes>} */
 const typedMessengers = new Map();

--- a/test/unit/src/inspector/InternalDiscoveryManager.test.js
+++ b/test/unit/src/inspector/InternalDiscoveryManager.test.js
@@ -132,7 +132,7 @@ async function basicSetup({
 		});
 
 		if (emulateStudioParent) {
-			/** @type {TypedMessenger<{}, import("../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers>} */
+			/** @type {TypedMessenger<import("../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers, {}>} */
 			const parentTypedMessenger = new TypedMessenger();
 			parentTypedMessenger.setResponseHandlers({
 				requestInternalDiscoveryUrl() {

--- a/test/unit/src/util/TypedMessenger/TypedMessenger.test.js
+++ b/test/unit/src/util/TypedMessenger/TypedMessenger.test.js
@@ -21,9 +21,9 @@ Deno.test({
 			returnsBool: () => true,
 		};
 
-		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
-		const messengerA = new TypedMessenger();
 		/** @type {TypedMessenger<{}, typeof requestHandlers>} */
+		const messengerA = new TypedMessenger();
+		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
 		const messengerB = new TypedMessenger();
 
 		// Normally we would send the data to the worker
@@ -135,9 +135,9 @@ Deno.test({
 			needsTransfer: (x, y) => {},
 		};
 
-		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
-		const messengerA = new TypedMessenger();
 		/** @type {TypedMessenger<{}, typeof requestHandlers>} */
+		const messengerA = new TypedMessenger();
+		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
 		const messengerB = new TypedMessenger();
 
 		/** @type {import("../../../../../src/util/TypedMessenger.js").TypedMessengerRequestMessage<typeof requestHandlers>[]} */
@@ -237,9 +237,9 @@ Deno.test({
 		};
 
 		const channel = new MessageChannel();
-		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
-		const messengerA = new TypedMessenger();
 		/** @type {TypedMessenger<{}, typeof requestHandlers>} */
+		const messengerA = new TypedMessenger();
+		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
 		const messengerB = new TypedMessenger();
 		messengerA.setSendHandler(data => {
 			channel.port2.postMessage(data.sendData);
@@ -298,9 +298,9 @@ Deno.test({
 			sameNum: x => x,
 		};
 
-		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
-		const messengerA = new TypedMessenger();
 		/** @type {TypedMessenger<{}, typeof requestHandlers>} */
+		const messengerA = new TypedMessenger();
+		/** @type {TypedMessenger<typeof requestHandlers, {}>} */
 		const messengerB = new TypedMessenger();
 		messengerA.setSendHandler(data => {
 			messengerB.handleReceivedMessage(data.sendData);
@@ -352,9 +352,9 @@ Deno.test({
 			},
 		};
 
-		/** @type {TypedMessenger<typeof requestHandlers, {}, true>} */
-		const messengerA = new TypedMessenger({returnTransferSupport: true});
 		/** @type {TypedMessenger<{}, typeof requestHandlers, true>} */
+		const messengerA = new TypedMessenger({returnTransferSupport: true});
+		/** @type {TypedMessenger<typeof requestHandlers, {}, true>} */
 		const messengerB = new TypedMessenger({returnTransferSupport: true});
 		messengerA.setSendHandler(data => {
 			messengerB.handleReceivedMessage(data.sendData);
@@ -464,7 +464,7 @@ Deno.test({
 		const worker = new Worker(url.href, {type: "module"});
 
 		try {
-			/** @type {TypedMessenger<import("./shared/workerWithInitialize.js").WorkerWithInitializeHandlers, WorkerWithInitializeHandlers, true>} */
+			/** @type {TypedMessenger<WorkerWithInitializeHandlers, import("./shared/workerWithInitialize.js").WorkerWithInitializeHandlers, true>} */
 			const messenger = new TypedMessenger({returnTransferSupport: true});
 			messenger.initialize(worker, workerWithInitializeHandlers);
 
@@ -560,7 +560,7 @@ Deno.test({
 			},
 		};
 
-		/** @type {TypedMessenger<{}, typeof handlers>} */
+		/** @type {TypedMessenger<typeof handlers, {}>} */
 		const messengerA = new TypedMessenger({
 			serializeErrorHook(error) {
 				if (error instanceof MyError) {
@@ -583,7 +583,7 @@ Deno.test({
 		 * @property {string} message
 		 */
 
-		/** @type {TypedMessenger<typeof handlers, {}>} */
+		/** @type {TypedMessenger<{}, typeof handlers>} */
 		const messengerB = new TypedMessenger({
 			deserializeErrorHook: error => {
 				if (error) {

--- a/test/unit/src/util/TypedMessenger/shared/workerWithInitialize.js
+++ b/test/unit/src/util/TypedMessenger/shared/workerWithInitialize.js
@@ -16,6 +16,6 @@ const requestHandlers = {
 	},
 };
 
-/** @type {TypedMessenger<import("../TypedMessenger.test.js").WorkerWithInitializeHandlers, typeof requestHandlers, true>} */
+/** @type {TypedMessenger<typeof requestHandlers, import("../TypedMessenger.test.js").WorkerWithInitializeHandlers, true>} */
 const messenger = new TypedMessenger({returnTransferSupport: true});
 messenger.initialize(globalThis, requestHandlers);

--- a/test/unit/studio/src/tasks/TaskManager.test.js
+++ b/test/unit/studio/src/tasks/TaskManager.test.js
@@ -164,7 +164,7 @@ Deno.test({
 				static type = "namespace:type";
 				static workerUrl = new URL("./shared/basicWorker.js", import.meta.url);
 
-				/** @type {TypedMessenger<import("./shared/basicWorker.js").BasicWorkerResponseHandlers, {}>} */
+				/** @type {TypedMessenger<{}, import("./shared/basicWorker.js").BasicWorkerResponseHandlers>} */
 				#messenger;
 
 				/** @param {ConstructorParameters<typeof Task>} args */

--- a/test/unit/studio/src/tasks/shared/basicWorker.js
+++ b/test/unit/studio/src/tasks/shared/basicWorker.js
@@ -2,7 +2,7 @@ import {TypedMessenger} from "../../../../../../src/util/TypedMessenger.js";
 
 /** @typedef {typeof responseHandlers} BasicWorkerResponseHandlers */
 
-/** @type {TypedMessenger<{}, BasicWorkerResponseHandlers>} */
+/** @type {TypedMessenger<BasicWorkerResponseHandlers, {}>} */
 const messenger = new TypedMessenger();
 messenger.setSendHandler(data => {
 	globalThis.postMessage(data.sendData);

--- a/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.test.js
+++ b/test/unit/studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.test.js
@@ -12,7 +12,7 @@ function installIframeContentWindow(buildview) {
 	const iframeEl = buildview.iframeEl;
 
 	/**
-	 * @type {TypedMessenger<import("../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers, {}>}
+	 * @type {TypedMessenger<{}, import("../../../../../../../studio/src/windowManagement/contentWindows/ContentWindowBuildView/ContentWindowBuildView.js").BuildViewIframeResponseHandlers>}
 	 */
 	const iframeWindowMessenger = new TypedMessenger();
 


### PR DESCRIPTION
I think it makes more sense for TypedMessengers to take its own handlers first and the handlers of the other messenger after that.