### PR TITLE
fix: Remove jsdoc example with import statement

### DIFF
--- a/src/util/TypedMessenger.js
+++ b/src/util/TypedMessenger.js
@@ -127,12 +127,6 @@
  * };
  * const messenger = new TypedMessenger<typeof myRequestHandlers, typeof workerRequestHandlers>();
  * ```
- * Or when using JSDoc:
- * @example
- * ```js
- * //** @ type {TypedMessenger<typeof myRequestHandlers, import("./yourWorkerOrServerFile").workerRequestHandlers>} * /
- * const messenger = new TypedMessenger();
- * ```
  * @template {TypedMessengerSignatures} TRes The handlers of this messenger.
  * @template {TypedMessengerSignatures} TReq The handlers of the other messenger.
  * @template {boolean} [TRequireHandlerReturnObjects = false]


### PR DESCRIPTION
This prevented `deno vendor` from working correctly. See https://github.com/denoland/deno/issues/20172