### PR TITLE
feat: Add timeout options to TypedMessenger

### DIFF
--- a/src/inspector/InternalDiscoveryManager.js
+++ b/src/inspector/InternalDiscoveryManager.js
@@ -101,7 +101,7 @@ export class InternalDiscoveryManager {
 		this.workerMessenger = new TypedMessenger();
 		this.workerMessenger.setResponseHandlers(this._getWorkerResponseHandlers());
 		this.workerMessenger.setSendHandler(async data => {
-			await this.iframeMessenger.sendWithTransfer.postWorkerMessage(data.transfer, data.sendData, data.transfer);
+			await this.iframeMessenger.sendWithOptions.postWorkerMessage({transfer: data.transfer}, data.sendData, data.transfer);
 		});
 
 		/**

--- a/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
+++ b/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
@@ -19,7 +19,7 @@ function getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destruct
 			 * @param {Transferable[]} transfer
 			 */
 			postWorkerMessage(data, transfer) {
-				workerTypedMessenger.sendWithTransfer.parentWindowToWorkerMessage(transfer, data);
+				workerTypedMessenger.sendWithOptions.parentWindowToWorkerMessage({transfer}, data);
 			},
 			async destructor() {
 				await destructorFunction();
@@ -31,7 +31,7 @@ function getHandlers({workerTypedMessenger, parentWindowTypedMessenger, destruct
 			 * @param {Transferable[]} transfer
 			 */
 			sendToParentWindow(data, transfer) {
-				parentWindowTypedMessenger.sendWithTransfer.workerToParentWindowMessage(transfer, data);
+				parentWindowTypedMessenger.sendWithOptions.workerToParentWindowMessage({transfer}, data);
 			},
 		},
 	};

--- a/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js
+++ b/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryWorkerMain.js
@@ -106,8 +106,8 @@ function getResponseHandlers(port, iframeMessenger, parentWindowMessenger, activ
 				if (!otherConnection) return;
 
 				const messageChannel = new MessageChannel();
-				createdConnection.parentMessenger.sendWithTransfer.connectionCreated([messageChannel.port1], otherClientId, messageChannel.port1, {});
-				otherConnection.parentMessenger.sendWithTransfer.connectionCreated([messageChannel.port2], createdConnection.id, messageChannel.port2, connectionData || {});
+				createdConnection.parentMessenger.sendWithOptions.connectionCreated({transfer: [messageChannel.port1]}, otherClientId, messageChannel.port1, {});
+				otherConnection.parentMessenger.sendWithOptions.connectionCreated({transfer: [messageChannel.port2]}, createdConnection.id, messageChannel.port2, connectionData || {});
 			},
 		},
 	};
@@ -148,7 +148,7 @@ export function initializeWorker(workerGlobal) {
 
 		parentMessenger.setResponseHandlers(parentWindowResponseHandlers);
 		parentMessenger.setSendHandler(data => {
-			iframeMessenger.sendWithTransfer.sendToParentWindow(data.transfer, data.sendData, data.transfer);
+			iframeMessenger.sendWithOptions.sendToParentWindow({transfer: data.transfer}, data.sendData, data.transfer);
 		});
 	});
 }

--- a/studio/src/tasks/workers/bundleAssets/bundle.js
+++ b/studio/src/tasks/workers/bundleAssets/bundle.js
@@ -13,7 +13,7 @@ export async function bundle(assetUuids, fileStreamId, messenger) {
 	// fill header with zeros
 	const emptyHeader = new ArrayBuffer(headerByteLength);
 	if (useFileStream) {
-		await messenger.sendWithTransfer.writeFile([emptyHeader], fileStreamId, emptyHeader);
+		await messenger.sendWithOptions.writeFile({transfer: [emptyHeader]}, fileStreamId, emptyHeader);
 	}
 
 	const header = new ArrayBuffer(headerByteLength);
@@ -65,7 +65,7 @@ export async function bundle(assetUuids, fileStreamId, messenger) {
 			transfer.push(assetData);
 		}
 		if (useFileStream) {
-			await messenger.sendWithTransfer.writeFile([], fileStreamId, assetData);
+			await messenger.send.writeFile(fileStreamId, assetData);
 		} else {
 			let buffer;
 			if (typeof assetData == "string") {
@@ -79,7 +79,7 @@ export async function bundle(assetUuids, fileStreamId, messenger) {
 
 	let returnValue = null;
 	if (useFileStream) {
-		await messenger.sendWithTransfer.writeFile([header], fileStreamId, {
+		await messenger.sendWithOptions.writeFile({transfer: [header]}, fileStreamId, {
 			type: "write",
 			position: 0,
 			data: header,

--- a/test/unit/src/util/TypedMessenger/shared/workerWithInitialize.js
+++ b/test/unit/src/util/TypedMessenger/shared/workerWithInitialize.js
@@ -7,7 +7,7 @@ const requestHandlers = {
 	 * @param {ArrayBuffer} arr
 	 */
 	async bar(arr) {
-		const result = await messenger.sendWithTransfer.foo([arr], arr);
+		const result = await messenger.sendWithOptions.foo({transfer: [arr]}, arr);
 		const arr2 = result.arr;
 		return {
 			returnValue: {arr: arr2},


### PR DESCRIPTION
When the other end of the connection is untrusted, we can't assume that they will always respond to every request.
And even if the other end is trusted, the connection might still drop before the typedmessenger is destroyed.

This change adds two options:
 - a `globalTimeout` option in the constructor of the `TypedMessenger`, or the `TypedMessenger.globalTimeout` value which can be modified directly.
 - `TypedMessenger.sendWithTransfer` is now renamed to `TypedMessenger.sendWithOptions` and a timeout can be provided for specific requests.