### PR TITLE
refactor(TypedMessenger): Remove old type for responsehandlers

### DIFF
--- a/src/util/TypedMessenger.js
+++ b/src/util/TypedMessenger.js
@@ -444,7 +444,7 @@ export class TypedMessenger {
 	 * messenger.initializeWorkerContext(responseHandlers);
 	 * ```
 	 * @param {Worker} worker
-	 * @param {ResponseHandlers} responseHandlers
+	 * @param {TRes} responseHandlers
 	 */
 	initializeWorker(worker, responseHandlers) {
 		this.setSendHandler(data => {
@@ -471,7 +471,7 @@ export class TypedMessenger {
 	 * const messenger = new TypedMessenger();
 	 * messenger.initializeWorkerContext(responseHandlers);
 	 * ```
-	 * @param {ResponseHandlers} responseHandlers
+	 * @param {TRes} responseHandlers
 	 */
 	initializeWorkerContext(responseHandlers) {
 		this.setSendHandler(data => {
@@ -497,7 +497,9 @@ export class TypedMessenger {
 	 * ```
 	 *
 	 * @param {WebSocket} webSocket
-	 * @param {ResponseHandlers} responseHandlers
+	 * @param {TRes} responseHandlers
+	 * @param {object} [options]
+	 * @param {boolean} [options.waitForOpen]
 	 */
 	initializeWebSocket(webSocket, responseHandlers) {
 		this.setSendHandler(data => {
@@ -609,18 +611,6 @@ export class TypedMessenger {
 	}
 
 	/**
-	 * Changes the type of a signature to allow both synchronous and asynchronous signatures.
-	 * @template {(...args: any[]) => any} T
-	 * @typedef {T extends (...args: infer Args) => infer ReturnType ?
-	 *	(...args: Args) => (Promise<ReturnType> | ReturnType) :
-	 * never} PromisifyReturnValue
-	 */
-
-	/**
-	 * @typedef {{[key in keyof TRes]: PromisifyReturnValue<TRes[key]>}} ResponseHandlers
-	 */
-
-	/**
 	 * Sets the collection of functions that the other end can call.
 	 *
 	 * ## Usage
@@ -639,7 +629,7 @@ export class TypedMessenger {
 	 * Now whenever the other end makes a call using {@linkcode send} on its own messenger (when
 	 * hooked up correctly to {@linkcode handleReceivedMessage}), your respective handler
 	 * will be called and its return value will be sent back to the other end.
-	 * @param {ResponseHandlers} handlers
+	 * @param {TRes} handlers
 	 */
 	setResponseHandlers(handlers) {
 		this.responseHandlers = handlers;


### PR DESCRIPTION
Not really sure why this was here in the first place.
I think the idea was to make autocompletions for `setResponseHandlers()` work or something.
Either way, this doesn't seem necessary anymore now, and in fact was causing some issues while working on #800.
Specifically, I was trying to pass an existing generic argument to the TypedMessenger, something like:
```js
/**
 * @template {TypedMessengerSignatures} TRes
 * @template {TypedMessengerSignatures} TReq
 * @param {TRes}
 */
function createMessenger(responseHandlers) {
    /** @type {TypedMessenger<TRes, TReq> */
    const messenger = new TypedMessenger();
    messenger.setResponseHandlers(responseHandlers);
    //                            ^^^^^^^^^^^^^^^^
    //               'TRes' is not assignable to parameter of type 'ResponseHandlers'
}
```