### PR TITLE
test: Add binary serialization test for unions of an object and null

### DIFF
--- a/test/unit/src/util/binarySerialization/unions.test.js
+++ b/test/unit/src/util/binarySerialization/unions.test.js
@@ -342,3 +342,37 @@ Deno.test({
 		}, opts);
 	},
 });
+
+Deno.test({
+	name: "Union of an object and null",
+	fn() {
+		const opts = createObjectToBinaryOptions({
+			structure: {
+				union: [
+					StorageType.UNION_ARRAY,
+					StorageType.NULL,
+					{
+						foo: StorageType.UINT8,
+						bar: StorageType.UINT8,
+					},
+				],
+			},
+			nameIds: {
+				union: 1,
+				foo: 2,
+				bar: 3,
+			},
+		});
+
+		basicObjectToBinaryToObjectTest({
+			union: null,
+		}, opts);
+
+		basicObjectToBinaryToObjectTest({
+			union: {
+				foo: 42,
+				bar: 123,
+			},
+		}, opts);
+	},
+});

--- a/test/unit/src/util/binarySerialization/unions.test.js
+++ b/test/unit/src/util/binarySerialization/unions.test.js
@@ -345,6 +345,7 @@ Deno.test({
 
 Deno.test({
 	name: "Union of an object and null",
+	ignore: true,
 	fn() {
 		const opts = createObjectToBinaryOptions({
 			structure: {


### PR DESCRIPTION
This will probably be fixed by #275 as well.