### PR TITLE
fix(Entity): Allow filtering the root when using traverseDown or traverseUp

### DIFF
--- a/src/core/Entity.js
+++ b/src/core/Entity.js
@@ -766,11 +766,10 @@ export class Entity {
 	*traverseDown({
 		filter = null,
 	} = {}) {
+		if (filter && !filter(this)) return;
 		yield this;
 		for (const child of this._children) {
-			if (filter == null || filter(child)) {
-				yield* child.traverseDown({filter});
-			}
+			yield* child.traverseDown({filter});
 		}
 	}
 
@@ -801,11 +800,10 @@ export class Entity {
 	*traverseUp({
 		filter = null,
 	} = {}) {
+		if (filter && !filter(this)) return;
 		yield this;
 		if (this.parent) {
-			if (filter == null || filter(this.parent)) {
-				yield* this.parent.traverseUp({filter});
-			}
+			yield* this.parent.traverseUp({filter});
 		}
 	}
 

--- a/test/unit/src/core/Entity/hierarchy.test.js
+++ b/test/unit/src/core/Entity/hierarchy.test.js
@@ -341,6 +341,19 @@ Deno.test({
 });
 
 Deno.test({
+	name: "traverseDown() with filter should exclude the root #821",
+	fn() {
+		const {root} = getBasicEntityStructure();
+
+		const result = Array.from(root.traverseDown({
+			filter: () => false,
+		}));
+
+		assertEquals(result.length, 0);
+	},
+});
+
+Deno.test({
 	name: "traverseUp()",
 	fn() {
 		const {
@@ -372,6 +385,19 @@ Deno.test({
 
 		assertEquals(result.length, 1);
 		assertStrictEquals(result[0], entity1A);
+	},
+});
+
+Deno.test({
+	name: "traverseUp() with filter should exclude the root #821",
+	fn() {
+		const {root} = getBasicEntityStructure();
+
+		const result = Array.from(root.traverseUp({
+			filter: () => false,
+		}));
+
+		assertEquals(result.length, 0);
 	},
 });
 


### PR DESCRIPTION
Fixes #821