### PR TITLE
Revert "chore: Add codecov upload token"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,6 @@ jobs:
 
       - name: Codecov
         uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: .coverage/cov.lcov
           flags: unittests


### PR DESCRIPTION
Reverts rendajs/Renda#869

It seems like this is causing an error when uploading results from commits:
> There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Could not find a repository associated with upload token ***', code='not_found')}

https://github.com/rendajs/Renda/actions/runs/8217264270/job/22472772275