### PR TITLE
refactor: Use beforeunload event instead of unload

### DIFF
--- a/src/network/studioConnections/discoveryMethods/InternalDiscoveryMethod.js
+++ b/src/network/studioConnections/discoveryMethods/InternalDiscoveryMethod.js
@@ -81,7 +81,7 @@ export class InternalDiscoveryMethod extends DiscoveryMethod {
 			await this.iframeMessenger.sendWithOptions.postWorkerMessage({ transfer: data.transfer }, data.sendData, data.transfer);
 		});
 
-		window.addEventListener("unload", () => {
+		window.addEventListener("beforeunload", () => {
 			this.destructor();
 		});
 	}

--- a/studio/src/misc/ServiceWorkerManager.js
+++ b/studio/src/misc/ServiceWorkerManager.js
@@ -117,7 +117,7 @@ export class ServiceWorkerManager {
 			});
 		}
 
-		window.addEventListener("unload", () => {
+		window.addEventListener("beforeunload", () => {
 			for (const messenger of this.#messengers.values()) {
 				messenger.send.unregisterClient();
 			}

--- a/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
+++ b/studio/src/network/studioConnections/internalDiscovery/internalDiscoveryIframeMain.js
@@ -84,7 +84,7 @@ export function initializeIframe(window) {
 	worker.port.start();
 
 	// Clean up when the page is unloaded or a destructor message is received.
-	window.addEventListener("unload", () => {
+	window.addEventListener("beforeunload", () => {
 		destructor();
 	});
 

--- a/test/unit/src/network/studioConnections/ParentStudioCommunicator.test.js
+++ b/test/unit/src/network/studioConnections/ParentStudioCommunicator.test.js
@@ -64,12 +64,8 @@ async function basicSetup({
 		await mockSessionAsync(async () => {
 			stub(window, "addEventListener", (...args) => {
 				const [type, listener] = args;
-				const castType = /** @type {string} */ (type);
 				if (type == "message") {
 					parentMessageEventListeners.add(listener);
-				} else if (castType == "unload") {
-					// The Deno test runner fires the unload event after the test is done
-					// ideally we'd write a test for this case but instead I'll just ignore this for now.
 				} else {
 					originalAddEventListener(...args);
 				}

--- a/test/unit/studio/src/misc/ServiceWorkerManager.test.js
+++ b/test/unit/studio/src/misc/ServiceWorkerManager.test.js
@@ -12,7 +12,7 @@ const SERVICE_WORKER_CLIENT_ID = "service worker client id";
  * @property {import("../../../../../studio/sw.js").TypedMessengerWithTypes} messenger
  * @property {import("std/testing/mock.ts").Spy<import("../../../../../studio/src/tasks/TaskManager.js").TaskManager, [taskType: string, taskConfig: unknown, options?: import("../../../../../studio/src/tasks/TaskManager.js").RunTaskOptions | undefined]>} runTaskSpy
  * @property {() => void} fireControllerChange
- * @property {() => void} fireUnload
+ * @property {() => void} fireBeforeUnload
  * @property {() => void} fireTimeout
  * @property {() => void} createInstallingWorker
  * @property {() => void} promoteInstallingWorker
@@ -76,7 +76,7 @@ async function basicTest({
 		/** @type {Set<() => void>} */
 		const onControllerChangeListeners = new Set();
 		/** @type {Set<() => void>} */
-		const unloadListeners = new Set();
+		const beforeUnloadListeners = new Set();
 		/** @type {Set<() => void>} */
 		const updateFoundListeners = new Set();
 
@@ -223,8 +223,8 @@ async function basicTest({
 			stub(window, "addEventListener", (...args) => {
 				const [type, listener] = args;
 				const castType = /** @type {string} */ (type);
-				if (castType == "unload") {
-					unloadListeners.add(/** @type {() => void} */ (listener));
+				if (castType == "beforeunload") {
+					beforeUnloadListeners.add(/** @type {() => void} */ (listener));
 				} else {
 					originalAddEventListener(...args);
 				}
@@ -240,8 +240,8 @@ async function basicTest({
 				fireControllerChange() {
 					onControllerChangeListeners.forEach((cb) => cb());
 				},
-				fireUnload() {
-					unloadListeners.forEach((cb) => cb());
+				fireBeforeUnload() {
+					beforeUnloadListeners.forEach((cb) => cb());
 				},
 				fireTimeout() {
 					if (!setTimeoutCallback) {
@@ -339,7 +339,7 @@ Deno.test({
 				const manager = new ServiceWorkerManager();
 				await manager.init();
 
-				ctx.fireUnload();
+				ctx.fireBeforeUnload();
 				assertSpyCalls(ctx.unregisterClientSpy, 1);
 			},
 		});


### PR DESCRIPTION
This appears to be functionally the same as the 'unload' event, except that this one isn't deprecated. An extra bonus is that 'beforeunload' doesn't deduct points from the 'best practices' section in lighthouse.