### PR TITLE
chore: Use OpenID Connect for Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,8 @@ jobs:
 
   unit-tests:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for codecov
     steps:
       - name: Setup repo
         uses: actions/checkout@93ea575cb5d8a053eaa0ac8fa3b40d7e05a33cc8

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,8 +89,9 @@ jobs:
         run: deno task test test/unit --coverage
 
       - name: Codecov
-        uses: codecov/codecov-action@d9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70
+        uses: codecov/codecov-action@84508663e988701840491b86de86b666e8a86bed
         with:
+          use_oidc: true
           files: .coverage/cov.lcov
           flags: unittests
 


### PR DESCRIPTION
Codecov has been failing lately, presumable because of https://github.com/codecov/codecov-action/issues/1359

This changes updates codecov to v4 and enables the 'use_oidc' flag.
Will this fix the issues? I don't know, but let's find out!